### PR TITLE
[Breaking change] Add support for options object including preferred temperature unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ import aioshelly
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        device = await aioshelly.Device.create("192.168.1.165", session)
-
-        # pprint(device.d)
-        # pprint(device.s)
+        device = await aioshelly.Device.create(session, "192.168.1.165")
 
         for block in device.blocks:
             print(block)

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 import json
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import aiohttp
 import aiocoap
@@ -43,6 +44,25 @@ class AuthRequired(ShellyError):
     """Raised during initialization if auth is required but not given."""
 
 
+@dataclass(frozen=True)
+class ConnectionOptions:
+    ip: str
+    username: Optional[str] = None
+    password: Optional[str] = None
+    temperature_unit: str = "C"
+    auth: Optional[aiohttp.BasicAuth] = None
+
+    def __post_init__(self):
+        """Called after initialization."""
+        if self.username is not None:
+            if self.password is None:
+                raise ValueError("Supply both username and password")
+
+            object.__setattr__(
+                self, "auth", aiohttp.BasicAuth(self.username, self.password)
+            )
+
+
 async def get_info(aiohttp_session: aiohttp.ClientSession, ip):
     async with aiohttp_session.get(
         f"http://{ip}/shelly", raise_for_status=True
@@ -55,14 +75,11 @@ class Device:
         self,
         coap_context: aiocoap.Context,
         aiohttp_session: aiohttp.ClientSession,
-        ip: str,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
+        options: ConnectionOptions,
     ):
         self.coap_context = coap_context
         self.aiohttp_session = aiohttp_session
-        self.auth = aiohttp.BasicAuth(username, password) if username else None
-        self.ip = ip
+        self.options = options
         self.d = None
         self.blocks = None
         self.s = None
@@ -70,19 +87,14 @@ class Device:
         self.shelly = None
 
     @classmethod
-    async def create(
-        cls,
-        ip,
-        aiohttp_session,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-    ):
-        if username is not None:
-            if password is None:
-                raise ValueError("Supply both username and password")
+    async def create(cls, aiohttp_session, ip_or_options: Union[str, ConnectionOptions]):
+        if isinstance(ip_or_options, str):
+            options = ConnectionOptions(ip_or_options)
+        else:
+            options = ip_or_options
 
         coap_context = await aiocoap.Context.create_client_context()
-        instance = cls(coap_context, aiohttp_session, ip, username, password)
+        instance = cls(coap_context, aiohttp_session, options)
 
         try:
             await instance.initialize()
@@ -92,8 +104,12 @@ class Device:
 
         return instance
 
+    @property
+    def ip(self):
+        return self.options.ip
+
     async def initialize(self):
-        self.shelly = await get_info(self.aiohttp_session, self.ip)
+        self.shelly = await get_info(self.aiohttp_session, self.options.ip)
 
         self.d = await self.coap_request("d")
         blocks = []
@@ -118,14 +134,16 @@ class Device:
 
         await self.update()
 
-        if self.auth or not self.shelly["auth"]:
+        if self.options.auth or not self.shelly["auth"]:
             self._settings = await self.http_request("get", "settings")
 
     async def update(self):
         self.s = {info[1]: info[2] for info in (await self.coap_request("s"))["G"]}
 
     async def coap_request(self, path):
-        request = aiocoap.Message(code=aiocoap.GET, uri=f"coap://{self.ip}/cit/{path}")
+        request = aiocoap.Message(
+            code=aiocoap.GET, uri=f"coap://{self.options.ip}/cit/{path}"
+        )
         response = await self.coap_context.request(request).response
         return json.loads(response.payload)
 
@@ -135,9 +153,9 @@ class Device:
 
         resp = await self.aiohttp_session.request(
             method,
-            f"http://{self.ip}/{path}",
+            f"http://{self.options.ip}/{path}",
             params=params,
-            auth=self.auth,
+            auth=self.options.auth,
             raise_for_status=True,
         )
         return await resp.json()
@@ -151,7 +169,7 @@ class Device:
 
     @property
     def read_only(self):
-        return self.auth is None and self.requires_auth
+        return self.options.auth is None and self.requires_auth
 
     @property
     def settings(self):
@@ -171,12 +189,14 @@ class Block:
         Block.TYPES[blk_type] = cls
 
     @staticmethod
-    def create(device, blk, sensors):
+    def create(device: Device, blk: dict, sensors: Dict[str, dict]):
         blk_type = blk["D"].split("_")[0]
         cls = Block.TYPES.get(blk_type, Block)
         return cls(device, blk_type, blk, sensors)
 
-    def __init__(self, device, blk_type, blk, sensors):
+    def __init__(
+        self, device: Device, blk_type: str, blk: dict, sensors: Dict[str, dict]
+    ):
         self.type = blk_type
         self.device = device
         # https://shelly-api-docs.shelly.cloud/#coiot-device-description-cit-d
@@ -196,7 +216,21 @@ class Block:
         #     "L": links
         # }
         self.sensors = sensors
-        self.sensor_ids = {val["D"]: val["I"] for val in sensors.values()}
+        sensor_ids = {}
+        for sensor in sensors.values():
+            if sensor["D"] not in sensor_ids:
+                sensor_ids[sensor["D"]] = sensor["I"]
+                continue
+
+            if sensor[BLOCK_VALUE_TYPE] != BLOCK_VALUE_TYPE_TEMPERATURE:
+                raise ValueError(
+                    "Found duplicate description for non-temperature sensor"
+                )
+
+            if sensor[BLOCK_VALUE_UNIT] == device.options.temperature_unit:
+                sensor_ids[sensor["D"]] = sensor["I"]
+
+        self.sensor_ids = sensor_ids
 
     @property
     def index(self):

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -87,7 +87,9 @@ class Device:
         self.shelly = None
 
     @classmethod
-    async def create(cls, aiohttp_session, ip_or_options: Union[str, ConnectionOptions]):
+    async def create(
+        cls, aiohttp_session, ip_or_options: Union[str, ConnectionOptions]
+    ):
         if isinstance(ip_or_options, str):
             options = ConnectionOptions(ip_or_options)
         else:

--- a/example.py
+++ b/example.py
@@ -1,7 +1,6 @@
 # Run with python3 example.py <ip of shelly device>
 import asyncio
 import sys
-from pprint import pprint
 
 import aiohttp
 import aioshelly
@@ -17,8 +16,10 @@ async def main():
         username = None
         password = None
 
+    options = aioshelly.ConnectionOptions(ip, username, password)
+
     async with aiohttp.ClientSession() as session:
-        device = await aioshelly.Device.create(ip, session, username, password)
+        device = await aioshelly.Device.create(session, options)
 
         # pprint(device.d)
         # pprint(device.s)
@@ -27,7 +28,18 @@ async def main():
 
         for block in device.blocks:
             print(block)
-            pprint(block.current_values())
+            for attr, value in block.current_values().items():
+                info = block.info(attr)
+
+                if value is None:
+                    value = "-"
+
+                if aioshelly.BLOCK_VALUE_UNIT in info:
+                    unit = " " + info[aioshelly.BLOCK_VALUE_UNIT]
+                else:
+                    unit = ""
+
+                print(f"{attr.ljust(16)}{value}{unit}")
             print()
 
             if light_relay_block is None and block.type in ("relay", "light"):


### PR DESCRIPTION
This is a breaking change: Now if you want to set a username and password, you first need to create a new ConnectionOptions object.

Introduces a new `ConnectionOptions` object that allows you to define device IP, username, password and preferred temperature unit.

Preferred temperature unit is used to filter out duplicate temperature readings for which both a C and F value exists.

Fixes #7 