### PR TITLE
Fix channel property when description doesn't contain "_"

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -275,7 +275,7 @@ class Block:
 
     @property
     def channel(self):
-        return self.description.split("_")[1]
+        return self.description.split("_")[1] if "_" in self.description else None
 
     def info(self, attr):
         """Return info over attribute."""


### PR DESCRIPTION
For some devices, the sensors are in the block with the description `device` and the `channel` property generates an error:
```
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity_platform.py", line 193, in _async_setup_platform
    await asyncio.shield(task)
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/sensor.py", line 116, in async_setup_entry
    await async_setup_entry_attribute_entities(
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 48, in async_setup_entry_attribute_entities
    [
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 49, in <listcomp>
    sensor_class(wrapper, block, sensor_id, description, counts[block.type])
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 148, in __init__
    name_parts.append(str(block.channel))
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.8/site-packages/aioshelly/__init__.py", line 280, in channel
    return self.description.split("_")[1]
IndexError: list index out of range
```
This PR fixes this.