### PR TITLE
Add firmware version check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": true
+}

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -62,7 +62,7 @@ BLOCK_VALUE_TYPE_STATUS = "S"  # (catch-all if no other fits)
 BLOCK_VALUE_TYPE_TEMPERATURE = "T"
 BLOCK_VALUE_TYPE_VOLTAGE = "V"
 
-# Firmware release date 1.8.0
+# Firmware 1.8.0 release date
 MIN_FIRMWARE_DATE = 20200812
 
 

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -116,7 +116,7 @@ def supported_firmware(ver_str: str):
         return False
     # We compare firmware release dates because Shelly version numbering is
     # inconsistent, sometimes the word is used as the version number.
-    return date > MIN_FIRMWARE_DATE
+    return date >= MIN_FIRMWARE_DATE
 
 
 class Device:

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -62,8 +62,8 @@ BLOCK_VALUE_TYPE_STATUS = "S"  # (catch-all if no other fits)
 BLOCK_VALUE_TYPE_TEMPERATURE = "T"
 BLOCK_VALUE_TYPE_VOLTAGE = "V"
 
+# Firmware release date 1.8.0
 MIN_FIRMWARE_DATE = 20200812
-
 
 class ShellyError(Exception):
     """Base class for aioshelly errors."""
@@ -113,6 +113,8 @@ def supported_firmware(ver_str: str):
         date = int(date_pattern.search(ver_str)[0])
     except TypeError:
         return False
+    # We compare firmware release dates because Shelly version numbering is
+    # inconsistent, sometimes the word is used as the version number.
     return date > MIN_FIRMWARE_DATE
 
 

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -65,6 +65,7 @@ BLOCK_VALUE_TYPE_VOLTAGE = "V"
 # Firmware release date 1.8.0
 MIN_FIRMWARE_DATE = 20200812
 
+
 class ShellyError(Exception):
     """Base class for aioshelly errors."""
 

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -75,7 +75,7 @@ class AuthRequired(ShellyError):
 
 
 class FirmwareUnsupported(ShellyError):
-    """Raised during initialization if device firmware version is unsupported."""
+    """Raised if device firmware version is unsupported."""
 
 
 @dataclass(frozen=True)

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -172,7 +172,6 @@ class Device:
     async def initialize(self):
         """Device initialization."""
         self.shelly = await get_info(self.aiohttp_session, self.options.ip_address)
-
         self._update_d(await self.coap_request("d"))
 
         await self.update()


### PR DESCRIPTION
Many users complain that the integration doesn't work because they try to configure the device with unsupported firmware. This PR adds a firmware version checking. The library will raise `FirmwareUnsupported` exception if device firmware is unsupported (too old).