### PR TITLE
Change the message type from CON to NON

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -219,7 +219,7 @@ class Device:
     async def coap_request(self, path):
         """Device CoAP request."""
         request = aiocoap.Message(
-            code=aiocoap.GET, uri=f"coap://{self.options.ip_address}/cit/{path}"
+            code=aiocoap.GET, mtype=aiocoap.NON, uri=f"coap://{self.options.ip_address}/cit/{path}"
         )
         response = await self.coap_context.request(request).response
         return json.loads(response.payload)

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -219,7 +219,9 @@ class Device:
     async def coap_request(self, path):
         """Device CoAP request."""
         request = aiocoap.Message(
-            code=aiocoap.GET, mtype=aiocoap.NON, uri=f"coap://{self.options.ip_address}/cit/{path}"
+            code=aiocoap.GET,
+            mtype=aiocoap.NON,
+            uri=f"coap://{self.options.ip_address}/cit/{path}",
         )
         response = await self.coap_context.request(request).response
         return json.loads(response.payload)


### PR DESCRIPTION
This PR changes the type of CoAP messages that `aioshelly` uses from `CON` to `NON` (from confirmable messages to non-confirmable messages).
I haven't found any downsides to this change and integration works well with it. I have confirmation from several people that after this change, Shelly devices return to the `available` state after power/network failure.

This fix is related with https://github.com/home-assistant/core/issues/40810 and https://github.com/home-assistant/core/issues/40411