### PR TITLE
Use a shared aiocoap context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 
 ## This library is under development.
 
-Requires Python 3.5 and uses asyncio, aiohttp and aiocoap.
+Requires Python 3 and uses asyncio, aiohttp and aiocoap.
 
 ```python
 import asyncio
 from pprint import pprint
+import aiocoap
 import aiohttp
 import aioshelly
 
 async def main():
     options = aioshelly.ConnectionOptions("192.168.1.165", "username", "password")
-    
+
+    coap_context = await aiocoap.Context.create_client_context()
+
     async with aiohttp.ClientSession() as session:
         device = await aioshelly.Device.create(session, options)
 
@@ -23,7 +26,7 @@ async def main():
             pprint(block.current_values())
             print()
 
-        await device.shutdown()
+    await coap_context.shutdown()
 
 
 if __name__ == "__main__":

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -146,7 +146,10 @@ class Device:
 
     @classmethod
     async def create(
-        cls, aiohttp_session, ip_or_options: Union[str, ConnectionOptions]
+        cls,
+        aiohttp_session: aiohttp.ClientSession,
+        coap_context: aiocoap.Context,
+        ip_or_options: Union[str, ConnectionOptions],
     ):
         """Device creation."""
         if isinstance(ip_or_options, str):
@@ -154,15 +157,8 @@ class Device:
         else:
             options = ip_or_options
 
-        coap_context = await aiocoap.Context.create_client_context()
         instance = cls(coap_context, aiohttp_session, options)
-
-        try:
-            await instance.initialize()
-        except Exception:
-            await coap_context.shutdown()
-            raise
-
+        await instance.initialize()
         return instance
 
     @property
@@ -239,10 +235,6 @@ class Device:
             raise_for_status=True,
         )
         return await resp.json()
-
-    async def shutdown(self):
-        """Device shutdown."""
-        await self.coap_context.shutdown()
 
     @property
     def requires_auth(self):

--- a/example.py
+++ b/example.py
@@ -1,8 +1,8 @@
 # Run with python3 example.py <ip of shelly device>
 import asyncio
-from contextlib import asynccontextmanager
 import sys
 import traceback
+from contextlib import asynccontextmanager
 
 import aiocoap
 import aiohttp


### PR DESCRIPTION
This updates the devices to use a shared Coap context instead of each device their own.

**Breaking change:** you now need to pass an `aiocoap_context` when creating a device.