### PR TITLE
Add semaphore to ensure maximum one request at a time

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -144,7 +144,7 @@ class Device:
         self._settings = None
         self.shelly = None
         self._status = None
-        self.sem = asyncio.Semaphore()
+        self.semaphore = asyncio.Semaphore()
 
     @classmethod
     async def create(
@@ -225,7 +225,7 @@ class Device:
             mtype=aiocoap.NON,
             uri=f"coap://{self.options.ip_address}/cit/{path}",
         )
-        async with self.sem:
+        async with self.semaphore:
             response = await self.coap_context.request(request).response
         return json.loads(response.payload)
 
@@ -234,7 +234,7 @@ class Device:
         if self.read_only:
             raise AuthRequired
 
-        async with self.sem:
+        async with self.semaphore:
             resp = await self.aiohttp_session.request(
                 method,
                 f"http://{self.options.ip_address}/{path}",

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -1,4 +1,5 @@
 """Shelly CoAP library."""
+import asyncio
 import json
 import re
 from dataclasses import dataclass
@@ -143,6 +144,7 @@ class Device:
         self._settings = None
         self.shelly = None
         self._status = None
+        self.sem = asyncio.Semaphore()
 
     @classmethod
     async def create(
@@ -223,7 +225,8 @@ class Device:
             mtype=aiocoap.NON,
             uri=f"coap://{self.options.ip_address}/cit/{path}",
         )
-        response = await self.coap_context.request(request).response
+        async with self.sem:
+            response = await self.coap_context.request(request).response
         return json.loads(response.payload)
 
     async def http_request(self, method, path, params=None):
@@ -231,13 +234,14 @@ class Device:
         if self.read_only:
             raise AuthRequired
 
-        resp = await self.aiohttp_session.request(
-            method,
-            f"http://{self.options.ip_address}/{path}",
-            params=params,
-            auth=self.options.auth,
-            raise_for_status=True,
-        )
+        async with self.sem:
+            resp = await self.aiohttp_session.request(
+                method,
+                f"http://{self.options.ip_address}/{path}",
+                params=params,
+                auth=self.options.auth,
+                raise_for_status=True,
+            )
         return await resp.json()
 
     async def shutdown(self):


### PR DESCRIPTION
This PR adds `semaphore` to ensure maximum one request at a time.

This change will fix issue #6