### PR TITLE
Remove listener on shutdown to help GC

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -193,6 +193,7 @@ class Device:
 
     def shutdown(self):
         """Shutdown device."""
+        self._update_listener = None
         self._unsub_listening()
 
     def _coap_message_received(self, msg):


### PR DESCRIPTION
When shutting down a device, also clear the listener so the object is easier to garbage collect.