### PR TITLE
Use gethostbyname to resolve hostname to IP address

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -162,10 +162,14 @@ class Device:
         ip_or_options: Union[str, ConnectionOptions],
     ):
         """Device creation."""
+        loop = asyncio.get_running_loop()
         if isinstance(ip_or_options, str):
-            options = ConnectionOptions(gethostbyname(ip_or_options))
+            ip_addr = await loop.run_in_executor(None, gethostbyname, ip_or_options)
+            options = ConnectionOptions(ip_addr)
         else:
-            ip_or_options.ip_address = gethostbyname(ip_or_options.ip_address)
+            ip_or_options.ip_address = await loop.run_in_executor(
+                None, gethostbyname, ip_or_options.ip_address
+            )
             options = ip_or_options
 
         instance = cls(coap_context, aiohttp_session, options)

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -163,7 +163,6 @@ class Device:
         ip_or_options: Union[str, ConnectionOptions],
     ):
         """Device creation."""
-        loop = asyncio.get_running_loop()
         if isinstance(ip_or_options, str):
             options = ConnectionOptions(ip_or_options)
         else:
@@ -172,6 +171,7 @@ class Device:
         try:
             ipaddress.ip_address(options.ip_address)
         except ValueError:
+            loop = asyncio.get_running_loop()
             options.ip_address = await loop.run_in_executor(
                 None, gethostbyname, options.ip_address
             )

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Union
+from socket import gethostbyname
 
 import aiohttp
 
@@ -83,7 +84,7 @@ class FirmwareUnsupported(ShellyError):
     """Raised if device firmware version is unsupported."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class ConnectionOptions:
     """Shelly options for connection."""
 
@@ -162,8 +163,9 @@ class Device:
     ):
         """Device creation."""
         if isinstance(ip_or_options, str):
-            options = ConnectionOptions(ip_or_options)
+            options = ConnectionOptions(gethostbyname(ip_or_options))
         else:
+            ip_or_options.ip_address = gethostbyname(ip_or_options.ip_address)
             options = ip_or_options
 
         instance = cls(coap_context, aiohttp_session, options)

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -2,8 +2,8 @@
 import asyncio
 import re
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
 from socket import gethostbyname
+from typing import Dict, Optional, Union
 
 import aiohttp
 


### PR DESCRIPTION
The CoAP listener needs the device's IP address, so with this change, `aioshelly` will use `socket.gethostbyname` to resolve hostname to IP address. This changed was suggested here https://github.com/home-assistant/core/pull/43963