### PR TITLE
Add support for initializing device when cit/s arrives

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## This library is under development.
 
-Requires Python 3 and uses asyncio, aiohttp and aiocoap.
+Requires Python 3 and uses asyncio, aiohttp, socket and netifaces.
 
 ```python
 import asyncio
@@ -41,13 +41,17 @@ The repository includes two examples to quickly try it out.
 Connect to a device and print its status whenever we receive a state change:
 
 ```
-python3 example.py <ip> [<username> <password]
+python3 example.py -ip <ip> [-u <username>] [-p <password]
 ```
 
 Connect to all the devices in `devices.json` at once and print their status:
 
 ```
-python3 example.py
+python3 example.py -d -i
+```
+## Show usage help:
+```
+python3 example.py -h
 ```
 
 ## Contribution guidelines

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -157,6 +157,8 @@ class Device:
         )
         self._update_listener = None
         self._coap_response_events: dict = {}
+        self._initialized = False
+        self._initializing = False
 
     @classmethod
     async def create(
@@ -164,6 +166,7 @@ class Device:
         aiohttp_session: aiohttp.ClientSession,
         coap_context: COAP,
         ip_or_options: Union[str, ConnectionOptions],
+        initialize: bool = True,
     ):
         """Device creation."""
         if isinstance(ip_or_options, str):
@@ -180,7 +183,10 @@ class Device:
             )
 
         instance = cls(coap_context, aiohttp_session, options)
-        await instance.initialize()
+
+        if initialize:
+            await instance.initialize(True)
+
         return instance
 
     @property
@@ -188,9 +194,15 @@ class Device:
         """Device ip address."""
         return self.options.ip_address
 
-    async def initialize(self):
+    async def initialize(self, request_s):
         """Device initialization."""
+        self._initializing = True
+
         self.shelly = await get_info(self.aiohttp_session, self.options.ip_address)
+
+        if self.options.auth or not self.shelly["auth"]:
+            await self.update_settings()
+            await self.update_status()
 
         event_d = await self.coap_request("d")
 
@@ -198,13 +210,15 @@ class Device:
         # Or else we might miss the answer to D
         await event_d.wait()
 
-        event_s = await self.coap_request("s")
+        if request_s:
+            event_s = await self.coap_request("s")
+            await event_s.wait()
 
-        if self.options.auth or not self.shelly["auth"]:
-            await self.update_settings()
-            await self.update_status()
+        self._initialized = True
+        self._initializing = False
 
-        await event_s.wait()
+        if self._update_listener:
+            self._update_listener(self)
 
     def shutdown(self):
         """Shutdown device."""
@@ -213,6 +227,10 @@ class Device:
 
     def _coap_message_received(self, msg):
         """CoAP message received."""
+        if not self._initializing and not self._initialized:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.initialize(False))
+
         if not msg.payload:
             return
         if "G" in msg.payload:
@@ -261,7 +279,7 @@ class Device:
         """Device update from cit/s call."""
         self.coap_s = {info[1]: info[2] for info in data["G"]}
 
-        if self._update_listener:
+        if self._update_listener and self._initialized:
             self._update_listener(self)
 
     def subscribe_updates(self, update_listener):
@@ -303,6 +321,11 @@ class Device:
     async def switch_light_mode(self, mode):
         """Change device mode color/white."""
         return await self.http_request("get", "settings", {"mode": mode})
+
+    @property
+    def initialized(self):
+        """Device initialized."""
+        return self._initialized
 
     @property
     def requires_auth(self):

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -83,6 +83,10 @@ class AuthRequired(ShellyError):
     """Raised during initialization if auth is required but not given."""
 
 
+class NotInitialized(ShellyError):
+    """Raised if device is not initialized."""
+
+
 class FirmwareUnsupported(ShellyError):
     """Raised if device firmware version is unsupported."""
 
@@ -340,6 +344,9 @@ class Device:
     @property
     def settings(self):
         """Device get settings (HTTP)."""
+        if not self._initialized:
+            raise NotInitialized
+
         if self._settings is None:
             raise AuthRequired
 
@@ -348,6 +355,9 @@ class Device:
     @property
     def status(self):
         """Device get status (HTTP)."""
+        if not self._initialized:
+            raise NotInitialized
+
         if self._status is None:
             raise AuthRequired
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
 # Run with python3 example.py <ip of shelly device>
+import argparse
 import asyncio
 import json
 import sys
@@ -10,39 +11,25 @@ import aiohttp
 import aioshelly
 
 
-async def cli():
-    if len(sys.argv) < 2:
-        print("Error! Run with <ip> <init> or <ip> <init> <user> <pass>")
-        return
-
-    ip = sys.argv[1]
-    init = bool(sys.argv[2] in ["True", "true", "1"])
-
-    if len(sys.argv) > 4:
-        username = sys.argv[3]
-        password = sys.argv[4]
-    else:
-        username = None
-        password = None
-
+async def test_single(ip, username, password, init, timeout):
     options = aioshelly.ConnectionOptions(ip, username, password)
 
     async with aiohttp.ClientSession() as aiohttp_session, aioshelly.COAP() as coap_context:
         try:
             device = await asyncio.wait_for(
-                aioshelly.Device.create(aiohttp_session, coap_context, options, init), 5
+                aioshelly.Device.create(aiohttp_session, coap_context, options, init),
+                timeout,
             )
         except asyncio.TimeoutError:
             print("Timeout connecting to", ip)
             return
 
-        if device.initialized:
-            print_device(device)
+        print_device(device)
 
         def device_updated(cb_device):
             print()
             print()
-            print(f"{datetime.now().strftime('%H:%m:%S')} Device updated!")
+            print(f"{datetime.now().strftime('%H:%M:%S')} Device updated!")
             print()
             print_device(cb_device)
 
@@ -52,7 +39,7 @@ async def cli():
             await asyncio.sleep(0.1)
 
 
-async def test_many():
+async def test_devices(init, timeout):
     device_options = []
     with open("devices.json") as fp:
         for line in fp:
@@ -62,7 +49,10 @@ async def test_many():
         results = await asyncio.gather(
             *[
                 asyncio.wait_for(
-                    connect_and_print_device(aiohttp_session, coap_context, options), 5
+                    connect_and_print_device(
+                        aiohttp_session, coap_context, options, init
+                    ),
+                    timeout,
                 )
                 for options in device_options
             ],
@@ -84,14 +74,17 @@ async def test_many():
             print(result)
 
 
-async def connect_and_print_device(aiohttp_session, coap_context, options):
-    device = await aioshelly.Device.create(aiohttp_session, coap_context, options)
+async def connect_and_print_device(aiohttp_session, coap_context, options, init):
+    device = await aioshelly.Device.create(aiohttp_session, coap_context, options, init)
     print_device(device)
 
 
 def print_device(device):
-    # pprint(device.coap_d)
-    # pprint(device.coap_s)
+    if not device.initialized:
+        print()
+        print(f"** Device @ {device.ip_address} not initialized **")
+        print()
+        return
 
     model = (
         aioshelly.MODEL_NAMES.get(device.settings["device"]["type"])
@@ -131,11 +124,53 @@ def print_device(device):
     #     )
 
 
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = argparse.ArgumentParser(description="aioshelly example")
+    parser.add_argument(
+        "--ip_address", "-ip", type=str, help="Test single device by IP address"
+    )
+    parser.add_argument(
+        "--devices",
+        "-d",
+        action="store_true",
+        help='Connect to all the devices in "devices.json" at once and print their status',
+    )
+    parser.add_argument(
+        "--init", "-i", action="store_true", help="Init device(s) at startup"
+    )
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        type=int,
+        default=5,
+        help="Device init timeout in seconds (default=5)",
+    )
+    parser.add_argument("--username", "-u", type=str, help="Set device username")
+    parser.add_argument("--password", "-p", type=str, help="Set device password")
+
+    arguments = parser.parse_args()
+
+    return parser, arguments
+
+
+async def main() -> None:
+    """Run main."""
+    parser, args = get_arguments()
+    if args.devices:
+        await test_devices(args.init, args.timeout)
+    elif args.ip_address:
+        if args.username and args.password is None:
+            parser.error("--username and --password must be used together")
+        await test_single(
+            args.ip_address, args.username, args.password, args.init, args.timeout
+        )
+    else:
+        parser.error("--ip_address or --devices must be specified")
+
+
 if __name__ == "__main__":
     try:
-        if len(sys.argv) < 2:
-            asyncio.run(test_many())
-        else:
-            asyncio.run(cli())
+        asyncio.run(main())
     except KeyboardInterrupt:
         pass

--- a/example.py
+++ b/example.py
@@ -26,13 +26,6 @@ async def test_single(ip, username, password, init, timeout):
 
         print_device(device)
 
-        def device_updated(cb_device):
-            print()
-            print()
-            print(f"{datetime.now().strftime('%H:%M:%S')} Device updated!")
-            print()
-            print_device(cb_device)
-
         device.subscribe_updates(device_updated)
 
         while True:
@@ -59,24 +52,36 @@ async def test_devices(init, timeout):
             return_exceptions=True,
         )
 
-    for options, result in zip(device_options, results):
-        if not isinstance(result, Exception):
-            continue
+        for options, result in zip(device_options, results):
+            if not isinstance(result, Exception):
+                continue
 
-        print()
-        print(f"Error printing device @ {options.ip_address}")
-
-        if isinstance(result, asyncio.TimeoutError):
-            print("Timeout connecting to device")
-        else:
             print()
-            traceback.print_tb(result.__traceback__)
-            print(result)
+            print(f"Error printing device @ {options.ip_address}")
+
+            if isinstance(result, asyncio.TimeoutError):
+                print("Timeout connecting to device")
+            else:
+                print()
+                traceback.print_tb(result.__traceback__)
+                print(result)
+
+        while True:
+            await asyncio.sleep(0.1)
 
 
 async def connect_and_print_device(aiohttp_session, coap_context, options, init):
     device = await aioshelly.Device.create(aiohttp_session, coap_context, options, init)
     print_device(device)
+    device.subscribe_updates(device_updated)
+
+
+def device_updated(cb_device):
+    print()
+    print()
+    print(f"{datetime.now().strftime('%H:%M:%S')} Device updated!")
+    print()
+    print_device(cb_device)
 
 
 def print_device(device):

--- a/example.py
+++ b/example.py
@@ -12,13 +12,15 @@ import aioshelly
 
 async def cli():
     if len(sys.argv) < 2:
-        print("Error! Run with <ip> or <ip> <user> <pass>")
+        print("Error! Run with <ip> <init> or <ip> <init> <user> <pass>")
         return
 
     ip = sys.argv[1]
-    if len(sys.argv) > 3:
-        username = sys.argv[2]
-        password = sys.argv[3]
+    init = bool(sys.argv[2] in ["True", "true", "1"])
+
+    if len(sys.argv) > 4:
+        username = sys.argv[3]
+        password = sys.argv[4]
     else:
         username = None
         password = None
@@ -28,20 +30,21 @@ async def cli():
     async with aiohttp.ClientSession() as aiohttp_session, aioshelly.COAP() as coap_context:
         try:
             device = await asyncio.wait_for(
-                aioshelly.Device.create(aiohttp_session, coap_context, options), 5
+                aioshelly.Device.create(aiohttp_session, coap_context, options, init), 5
             )
         except asyncio.TimeoutError:
             print("Timeout connecting to", ip)
             return
 
-        print_device(device)
+        if device.initialized:
+            print_device(device)
 
-        def device_updated(device):
+        def device_updated(cb_device):
             print()
             print()
             print(f"{datetime.now().strftime('%H:%m:%S')} Device updated!")
             print()
-            print_device(device)
+            print_device(cb_device)
 
         device.subscribe_updates(device_updated)
 


### PR DESCRIPTION
Add `initialize` parameter to `Device.create`, default to `True`
If set to `False` will not initialize device on create but only after `cit/s` CoAP message arrives from the device.
Add new property `initialized` which set to `True` after initialization finished.
Raise `NotInitialized` exception when trying to get value from non-initialized device.
Migrate to `argparse`