### PR TITLE
Add multicast querier thread

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Union
 
 import aiohttp
 
+from .coap import MulticastQuerier  # noqa: F401
 from .coap import COAP
 
 MODEL_NAMES = {

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -113,7 +113,7 @@ class ConnectionOptions:
 
 
 async def get_info(aiohttp_session: aiohttp.ClientSession, ip_address):
-    """Get info from device trough REST call."""
+    """Get info from device through REST call."""
     async with aiohttp_session.get(
         f"http://{ip_address}/shelly", raise_for_status=True
     ) as resp:

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -56,7 +56,6 @@ def get_network_objects(objtype: str):
     """Get all ip/iface from system interfaces."""
     obj_list = []
     ifaces = netifaces.interfaces()
-    ifaces.remove("lo")
 
     for iface in ifaces:
         iface_details = netifaces.ifaddresses(iface)
@@ -90,10 +89,10 @@ class MulticastQuerier:
     def __init__(self):
         """Initialize multicast querier thread."""
         loop = asyncio.get_event_loop()
-        loop.run_in_executor(None, self.async_start)
+        loop.run_in_executor(None, self.start)
 
     @classmethod
-    def async_start(cls):
+    def start(cls):
         """Start sniffing for multicast query."""
         filter_igmp_query = f"igmp and igmp[0] == {int(MULTICAST_QUERY_IGMPTYPE)} and (igmp[4:4] == {int(ipaddress.IPv4Address(MAIN_MULTICAST_IP))} or igmp[4:4] == 0)"
         pkt_snd = IP(dst=MULTICAST_QUERY_GRP) / IGMP(
@@ -121,10 +120,6 @@ class MulticastQuerier:
                 _LOGGER.info(
                     "Multicast query received from network, no action required"
                 )
-            _LOGGER.debug(
-                "Multicast querier sleeping for %s seconds", MULTICAST_QUERY_TIMEOUT
-            )
-            time.sleep(MULTICAST_QUERY_TIMEOUT)
 
 
 class COAP(asyncio.DatagramProtocol):

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -121,7 +121,7 @@ class MulticastQuerier:
     def start(self):
         """Start multicast querier thread."""
         self.stop_thread = False
-        self.thread = threading.Thread(target=self.run)
+        self.thread = threading.Thread(target=self.run, daemon=True)
         self.thread.start()
         _LOGGER.debug("Multicast querier thread started")
 

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -132,7 +132,7 @@ class MulticastQuerier:
         self.thread = threading.Thread(
             name="MulticastQuerierThread", target=self.run, daemon=True
         )
-        _LOGGER.debug("Multicast querier thread started")
+        _LOGGER.debug("Starting multicast querier thread")
         self.thread.start()
 
     def run(self):
@@ -152,7 +152,7 @@ class MulticastQuerier:
             )
             _LOGGER.debug("Multicast query sniff result: %s", result)
             if not result:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Multicast query not received in %s seconds",
                     MULTICAST_QUERY_TIMEOUT,
                 )
@@ -160,13 +160,13 @@ class MulticastQuerier:
                     send(pkt_snd, iface=eth_iface, verbose=False)
                     _LOGGER.info("Multicast query sent for %s interface", eth_iface)
             else:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Multicast query received from network, no action required"
                 )
 
     def stop(self):
         """Stop multicast querier thread."""
-        _LOGGER.debug("Multicast querier thread stopped")
+        _LOGGER.debug("Stopping multicast querier thread")
         self.stop_thread = True
 
 

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -121,7 +121,9 @@ class MulticastQuerier:
     def start(self):
         """Start multicast querier thread."""
         self.stop_thread = False
-        self.thread = threading.Thread(name="MulticastQuerierThread", target=self.run, daemon=True)
+        self.thread = threading.Thread(
+            name="MulticastQuerierThread", target=self.run, daemon=True
+        )
         self.thread.start()
         _LOGGER.debug("Multicast querier thread started")
 

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -118,7 +118,7 @@ class MulticastQuerier:
         self.stop_thread = None
         self.thread = None
 
-    def start(self):
+    async def start(self):
         """Start multicast querier thread."""
         self.stop_thread = False
         self.thread = threading.Thread(
@@ -156,7 +156,7 @@ class MulticastQuerier:
                     "Multicast query received from network, no action required"
                 )
 
-    def stop(self):
+    async def stop(self):
         """Stop multicast querier thread."""
         _LOGGER.debug("Multicast querier thread stopped")
         self.stop_thread = True
@@ -172,15 +172,12 @@ class COAP(asyncio.DatagramProtocol):
         self._message_received = message_received
         self.subscriptions = {}
         self.transport: Optional[asyncio.DatagramTransport] = None
-        self.querier = None
 
     async def initialize(self):
         """Initialize the COAP manager."""
         loop = asyncio.get_running_loop()
         self.sock = socket_init()
         await loop.create_datagram_endpoint(lambda: self, sock=self.sock)
-        self.querier = MulticastQuerier()
-        self.querier.start()
 
     async def request(self, ip: str, path: str):
         """Request a CoAP message.
@@ -194,7 +191,6 @@ class COAP(asyncio.DatagramProtocol):
     def close(self):
         """Close."""
         self.transport.close()
-        self.querier.stop()
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """When the socket is set up."""

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -96,6 +96,7 @@ def verify_l2socket_creation_permission():
     thread so we will not be able to capture
     any permission or bind errors.
     """
+    conf.sniff_promisc = 0
     sock = conf.L2socket()
     sock.close()
 

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -5,7 +5,6 @@ import json
 import logging
 import socket
 import struct
-import time
 from typing import Optional, cast
 
 import netifaces

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -95,8 +95,8 @@ def verify_l2socket_creation_permission():
     thread so we will not be able to capture
     any permission or bind errors.
     """
-    s = conf.L2socket()
-    s.close()
+    sock = conf.L2socket()
+    sock.close()
 
 
 class MulticastQuerier:
@@ -115,10 +115,12 @@ class MulticastQuerier:
                     ex,
                 )
             return
-        self.stop_thread = False
+        self.stop_thread = None
+        self.thread = None
 
     def start(self):
         """Start multicast querier thread."""
+        self.stop_thread = False
         self.thread = threading.Thread(target=self.run)
         self.thread.start()
         _LOGGER.debug("Multicast querier thread started")

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -121,7 +121,7 @@ class MulticastQuerier:
     def start(self):
         """Start multicast querier thread."""
         self.stop_thread = False
-        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread = threading.Thread(name="MulticastQuerierThread", target=self.run, daemon=True)
         self.thread.start()
         _LOGGER.debug("Multicast querier thread started")
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
 [mypy-netifaces]
 ignore_missing_imports = True
 
+[mypy-scapy.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
 netifaces
+scapy


### PR DESCRIPTION
Unfortunately some routers/AP doesn't behave as multicast querier.

This leads to missing status query for the multicast group, thus making interested network devices (servers, client, etc.) to leave the group.
When HA server leaves the group, it stops receiving the CoAP status update packets loosing real time sync with Shelly devices.

This PR checks every 4 minutes ( longer interval in real world is 5 minutes ), if a multicast query packet is received and if not it sends one.

