### PR TITLE
Revert multiple interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## This library is under development.
 
-Requires Python 3 and uses asyncio, aiohttp, socket and netifaces.
+Requires Python 3 and uses asyncio, aiohttp and socket.
 
 ```python
 import asyncio

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -6,11 +6,7 @@ import socket
 import struct
 from typing import Optional, cast
 
-import netifaces
-
 _LOGGER = logging.getLogger(__name__)
-
-MULTICAST_IP = "224.0.1.187"
 
 
 class CoapMessage:
@@ -42,27 +38,13 @@ class CoapMessage:
             self.payload = None
 
 
-def get_all_ips():
-    """Get all ip from ethernet interfaces."""
-    ip_list = []
-    for iface in netifaces.interfaces():
-        iface_details = netifaces.ifaddresses(iface)
-        if netifaces.AF_INET in iface_details:
-            ip_list.append(iface_details[netifaces.AF_INET][0]["addr"])
-    return ip_list
-
-
 def socket_init():
     """Init UDP socket to send/receive data with Shelly devices."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", 5683))
-
-    for ip in get_all_ips():
-        _LOGGER.debug("Adding ip %s to multicast %s membership", ip, MULTICAST_IP)
-        group = socket.inet_aton(MULTICAST_IP) + socket.inet_aton(ip)
-        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, group)
-
+    mreq = struct.pack("=4sl", socket.inet_aton("224.0.1.187"), socket.INADDR_ANY)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
     sock.setblocking(False)
     return sock
 

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -10,8 +10,7 @@ import netifaces
 
 _LOGGER = logging.getLogger(__name__)
 
-MAIN_MULTICAST_IP = "224.0.1.187"
-WF200_MULTICAST_IP = "224.0.1.188"
+MULTICAST_IP = "224.0.1.187"
 
 
 class CoapMessage:
@@ -60,10 +59,9 @@ def socket_init():
     sock.bind(("", 5683))
 
     for ip in get_all_ips():
-        for multicast_ip in MAIN_MULTICAST_IP, WF200_MULTICAST_IP:
-            _LOGGER.debug("Adding ip %s to multicast %s membership", ip, multicast_ip)
-            group = socket.inet_aton(multicast_ip) + socket.inet_aton(ip)
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, group)
+        _LOGGER.debug("Adding ip %s to multicast %s membership", ip, MULTICAST_IP)
+        group = socket.inet_aton(MULTICAST_IP) + socket.inet_aton(ip)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, group)
 
     sock.setblocking(False)
     return sock

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy-netifaces]
-ignore_missing_imports = True
-

--- a/pylintrc
+++ b/pylintrc
@@ -41,7 +41,6 @@ score=no
 [TYPECHECK]
 # For attrs
 ignored-classes=_CountingAttr
-generated-members=netifaces
 
 [FORMAT]
 expected-line-ending-format=LF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp
-netifaces

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open("README.md").read()
 
 setup(
     name="aioshelly",
-    version="0.5.4",
+    version="0.6.0",
     license="Apache License 2.0",
     url="https://github.com/home-assistant-libs/aioshelly",
     author="Paulus Schoutsen",


### PR DESCRIPTION
Revert PR: #53, #60
Bump version to 0.6.0

## Breaking change
Library is no longer listening on multiple interfaces, only on the default interface. 
Multicast group `224.0.1.188` removed

