### PR TITLE
Fix coap logging

### DIFF
--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -26,7 +26,7 @@ class CoapMessage:
             try:
                 self.payload = json.loads(payload.rsplit(b"\xff", 1)[1].decode())
             except (json.decoder.JSONDecodeError, IndexError):
-                _LOGGER.error(
+                _LOGGER.debug(
                     "CoAP message of type %s from host %s is not a valid JSON format: %s",
                     self.code,
                     self.ip,

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -9,6 +9,14 @@ from typing import Optional, cast
 _LOGGER = logging.getLogger(__name__)
 
 
+class CoapError(Exception):
+    """Base class for COAP errors."""
+
+
+class InvalidMessage(CoapError):
+    """Raised during COAP message parsing errors."""
+
+
 class CoapMessage:
     """Represents a received coap message."""
 
@@ -20,22 +28,17 @@ class CoapMessage:
         try:
             self.vttkl, self.code, self.mid = struct.unpack("!BBH", payload[:4])
         except struct.error as err:
-            raise ValueError("Incoming message too short for CoAP") from err
+            raise InvalidMessage("Message too short") from err
 
-        if self.code in (30, 69):
-            try:
-                self.payload = json.loads(payload.rsplit(b"\xff", 1)[1].decode())
-            except (json.decoder.JSONDecodeError, IndexError):
-                _LOGGER.debug(
-                    "CoAP message of type %s from host %s is not a valid JSON format: %s",
-                    self.code,
-                    self.ip,
-                    payload,
-                )
-                self.payload = None
-        else:
-            _LOGGER.debug("Received packet type: %s, host ip: %s", self.code, self.ip)
-            self.payload = None
+        if self.code not in (30, 69):
+            raise InvalidMessage(f"Wrong type, {self.code}")
+
+        try:
+            self.payload = json.loads(payload.rsplit(b"\xff", 1)[1].decode())
+        except (json.decoder.JSONDecodeError, IndexError) as err:
+            raise InvalidMessage(
+                f"Message type {self.code} is not a valid JSON format: {payload}"
+            ) from err
 
 
 def socket_init():
@@ -85,10 +88,14 @@ class COAP(asyncio.DatagramProtocol):
 
     def datagram_received(self, data, addr):
         """Handle incoming datagram messages."""
-        msg = CoapMessage(addr, data)
-
-        # Don't know how to handle these right now.
-        if msg.payload is None:
+        host_ip = addr[0]
+        try:
+            msg = CoapMessage(addr, data)
+        except InvalidMessage as err:
+            if host_ip in self.subscriptions:
+                _LOGGER.error("Invalid Message from known host %s: %s", host_ip, err)
+            else:
+                _LOGGER.debug("Invalid Message from unknown host %s: %s", host_ip, err)
             return
 
         if self._message_received:

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -37,7 +37,7 @@ class CoapMessage:
             self.payload = json.loads(payload.rsplit(b"\xff", 1)[1].decode())
         except (json.decoder.JSONDecodeError, IndexError) as err:
             raise InvalidMessage(
-                f"Message type {self.code} is not a valid JSON format: {payload}"
+                f"Message type {self.code} is not a valid JSON format: {str(payload)}"
             ) from err
 
 


### PR DESCRIPTION
Change CoAP message parsing log level from error to debug to avoid logging errors for devices which are not Shelly devices and sends CoAP messages.
This PR fixes issue: https://github.com/home-assistant-libs/aioshelly/issues/72