### PR TITLE
Shelly 4Pro and Shelly Sense are unsupported

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -1,8 +1,8 @@
 """Shelly CoAP library."""
 import asyncio
+from dataclasses import dataclass
 import ipaddress
 import re
-from dataclasses import dataclass
 from socket import gethostbyname
 from typing import Dict, Optional, Union
 
@@ -37,7 +37,7 @@ MODEL_NAMES = {
     "SHPLG2-1": "Shelly Plug E",
     "SHRGBW2": "Shelly RGBW2",
     "SHRGBWW-01": "Shelly RGBW",
-    "SHSEN-1": "Shelly Sense", # CoAP v1, unsupported
+    "SHSEN-1": "Shelly Sense",  # CoAP v1, unsupported
     "SHSM-01": "Shelly Smoke",
     "SHSM-02": "Shelly Smoke 2",
     "SHSPOT-1": "Shelly Spot",
@@ -45,7 +45,7 @@ MODEL_NAMES = {
     "SHSW-1": "Shelly 1",
     "SHSW-21": "Shelly 2",
     "SHSW-25": "Shelly 2.5",
-    "SHSW-44": "Shelly 4Pro", # CoAP v1, unsupported
+    "SHSW-44": "Shelly 4Pro",  # CoAP v1, unsupported
     "SHSW-L": "Shelly 1L",
     "SHSW-PM": "Shelly 1PM",
     "SHUNI-1": "Shelly UNI",

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -119,7 +119,8 @@ async def get_info(aiohttp_session: aiohttp.ClientSession, ip_address):
     ) as resp:
         result = await resp.json()
 
-    if not supported_firmware(result["fw"]):
+    # Shelly4Pro will never get CoAP v2, but still get some firmware updates
+    if not supported_firmware(result["fw"]) or result["type"] == "SHSW-44":
         raise FirmwareUnsupported
 
     return result

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -37,7 +37,7 @@ MODEL_NAMES = {
     "SHPLG2-1": "Shelly Plug E",
     "SHRGBW2": "Shelly RGBW2",
     "SHRGBWW-01": "Shelly RGBW",
-    "SHSEN-1": "Shelly Sense",
+    "SHSEN-1": "Shelly Sense", # CoAP v1, unsupported
     "SHSM-01": "Shelly Smoke",
     "SHSM-02": "Shelly Smoke 2",
     "SHSPOT-1": "Shelly Spot",
@@ -45,7 +45,7 @@ MODEL_NAMES = {
     "SHSW-1": "Shelly 1",
     "SHSW-21": "Shelly 2",
     "SHSW-25": "Shelly 2.5",
-    "SHSW-44": "Shelly 4Pro",
+    "SHSW-44": "Shelly 4Pro", # CoAP v1, unsupported
     "SHSW-L": "Shelly 1L",
     "SHSW-PM": "Shelly 1PM",
     "SHUNI-1": "Shelly UNI",
@@ -119,8 +119,7 @@ async def get_info(aiohttp_session: aiohttp.ClientSession, ip_address):
     ) as resp:
         result = await resp.json()
 
-    # Shelly4Pro will never get CoAP v2, but still get some firmware updates
-    if not supported_firmware(result["fw"]) or result["type"] == "SHSW-44":
+    if not supported_firmware(result["fw"]) or result["type"] in ["SHSW-44", "SHSEN-1"]:
         raise FirmwareUnsupported
 
     return result

--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -1,8 +1,8 @@
 """Shelly CoAP library."""
 import asyncio
-from dataclasses import dataclass
 import ipaddress
 import re
+from dataclasses import dataclass
 from socket import gethostbyname
 from typing import Dict, Optional, Union
 


### PR DESCRIPTION
Force Shelly4Pro and Shelly Sense unsupported firmware message based on device type and not on firmware release date.

Those devices will never get CoAP v2, but still get some firmware update