### PR TITLE
Add trigger_ota_update device method

### DIFF
--- a/aioshelly/__init__.py
+++ b/aioshelly/__init__.py
@@ -346,6 +346,17 @@ class Device:
         """Change device mode color/white."""
         return await self.http_request("get", "settings", {"mode": mode})
 
+    async def trigger_ota_update(self, beta=False, url=None):
+        """Trigger an ota update."""
+        params = {"update": "true"}
+
+        if url:
+            params = {"url": url}
+        elif beta:
+            params = {"beta": "true"}
+
+        return await self.http_request("get", "ota", params=params)
+
     @property
     def initialized(self):
         """Device initialized."""


### PR DESCRIPTION
This PR will add a new device method `trigger_ota_update` which allows to trigger an ota update according to https://shelly-api-docs.shelly.cloud/#ota.

### Usage:

#### without parameters
Run firmware update from default URL  (`new_version`)
#### with given `url` parameter
Run firmware update from specified URL
#### with given `beta` parameter
Run firmware update from beta URL (if available)
#### with both given `beta` and `url` parameter
Still run firmware update from specified URL (_IMHO because url is more specific than beta_)