### PR TITLE
Revert BlockDevice shutdown to sync

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -113,7 +113,7 @@ class BlockDevice:
         if self._update_listener:
             self._update_listener(self)
 
-    async def shutdown(self):
+    def shutdown(self):
         """Shutdown device."""
         self._update_listener = None
         self._unsub_listening()


### PR DESCRIPTION
`BlockDevice` shutdown method was changed to async to be compatible with `RpcDevice` since common `Device` class is removed this is not needed and better changed back to sync