### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open("README.md").read()
 
 setup(
     name="aioshelly",
-    version="0.6.4",
+    version="1.0.0",
     license="Apache License 2.0",
     url="https://github.com/home-assistant-libs/aioshelly",
     author="Paulus Schoutsen",


### PR DESCRIPTION
# Bump version to 1.0.0

## Overview
Shelly Gen2 devices are based on RPC over Web socket and are not backward compatible with Gen1 (CoAP based) devices.
This is a refactor of the `aioshelly` library and has breaking changes. Library will support both Gen1 & Gen2 devices.

More details about Gen2 devices API can be found here: https://shelly-api-docs.shelly.cloud/gen2/
## Files content
Library is built from the following files:
- `__init__.py` - holds a Device class which creates either Gen1 or Gen2 device
- `coap.py` - handles low level CoAP communication with Gen1 devices (unchanged)
- `block_device.py` - Block based Gen1 device class (previously located under `__init__.py`)
- `wsrpc.py` - handles low level Web socket RPC communication with Gen2 devices (new)
- `rpc_device.py` - RPC based Gen2 device class (new)
- `common` - common functions for both Gen1 & Gen2 devices (previously located under `__init__.py`)
- `const.py` - constants and model names for both Gen1 & Gen2 devices (previously located under `__init__.py`)
- `exceptions.py`- exceptions for both Gen1 & Gen2 devices (previously located under `__init__.py`)

## Breaking changes
Due to refactoring for supporting Gen2 devices the main device class is now a new class and most content for Block based devices is moved to `block_device`, in most cases this results by imports using Gen1 block device changed, major changes:
- `from aioshelly import Block` is changed to `from aioshelly.block_device import Block`
- Constants should be imported from `aioshelly.const` instead from `aioshelly`
- Exceptions should be imported from `aioshelly.exceptions` instead from `aioshelly`
- `request_s` which was for internal use is removed from `device.initialize`
- ` ConnectionOptions` and `get_info` are now at `common.py` instead of `__init__.py`

## Testing
`Device.create` has a new parameter `gen` which is set to `1` by default, if set to `2` it will create a Gen2 device class.
`example.py` updated to support Gen2 devices, testing Gen2 devices can be done by adding `--gen2` or `-g2` to the command line parameters.

**From version 1.0.0 code is fully typed and `mypy` strict typing is enabled**