### PR TITLE
Add trigger_ota_update for gen2 devices

### DIFF
--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -114,7 +114,6 @@ class RpcDevice:
         """Trigger an ota update."""
         params = {"stage": "beta"} if beta else {"stage": "stable"}
         await self._wsrpc.call("Shelly.Update", params)
-        return None
 
     async def update_status(self) -> None:
         """Get device status from 'Shelly.GetStatus'."""


### PR DESCRIPTION
Add `trigger_ota_update()` for gen2 Devices.
(ref: https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonServices/Shelly/#shellyupdate)

Closes issue #145 