### PR TITLE
Fix RPC device - skip status until device is initialized

### DIFF
--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -64,7 +64,8 @@ class RpcDevice:
     ) -> None:
         if params is not None:
             if method == "NotifyStatus":
-                assert self._status
+                if self._status is None:
+                    return
                 self._status = dict(mergedicts(self._status, params))
             elif method == "NotifyEvent":
                 self._event = params


### PR DESCRIPTION
A status update from the device may happen while we are still in the init stage, in this case the status update is skipped since during init we pull the full status