### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open("README.md").read()
 
 setup(
     name="aioshelly",
-    version="1.0.2",
+    version="1.0.3",
     license="Apache License 2.0",
     url="https://github.com/home-assistant-libs/aioshelly",
     author="Paulus Schoutsen",


### PR DESCRIPTION
# Bump version to 1.0.3

## What's Changed
* Fix RPC device - skip status until device is initialized (#153) @thecode
* Add new Shelly model names (#154) @thecode
* Handle Unicode decode error (#152) @chemelli74
* Add trigger_ota_update for gen2 devices (#150) @chemelli74
