### PR TITLE
Add missing timeout to client sessions

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -224,6 +224,7 @@ class BlockDevice:
             params=params,
             auth=self.options.auth,
             raise_for_status=True,
+            timeout=BLOCK_DEVICE_INIT_TIMEOUT,
         )
         return cast(dict, await resp.json())
 

--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -11,7 +11,7 @@ from aiohttp.client_reqrep import ClientResponse
 
 from .coap import COAP, CoapMessage
 from .common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
-from .const import BLOCK_DEVICE_INIT_TIMEOUT
+from .const import BLOCK_DEVICE_INIT_TIMEOUT, HTTP_CALL_TIMEOUT
 from .exceptions import AuthRequired, NotInitialized, WrongShellyGen
 
 BLOCK_VALUE_UNIT = "U"
@@ -224,7 +224,7 @@ class BlockDevice:
             params=params,
             auth=self.options.auth,
             raise_for_status=True,
-            timeout=BLOCK_DEVICE_INIT_TIMEOUT,
+            timeout=HTTP_CALL_TIMEOUT,
         )
         return cast(dict, await resp.json())
 

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -63,7 +63,7 @@ async def get_info(
     aiohttp_session: aiohttp.ClientSession, ip_address: str
 ) -> dict[str, Any]:
     """Get info from device through REST call."""
-    with async_timeout.timeout(HTTP_CALL_TIMEOUT):
+    async with async_timeout.timeout(HTTP_CALL_TIMEOUT):
         async with aiohttp_session.get(
             f"http://{ip_address}/shelly", raise_for_status=True
         ) as resp:

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -51,6 +51,9 @@ MODEL_NAMES = {
 # Timeout used for Block Device init
 BLOCK_DEVICE_INIT_TIMEOUT = 10
 
+# Timeout used for HTTP calls
+HTTP_CALL_TIMEOUT = 10
+
 # Firmware 1.8.0 release date (CoAP v2)
 GEN1_MIN_FIRMWARE_DATE = 20200812
 


### PR DESCRIPTION
Missing timeout has undesirable side effects, like applying default 300s.

This PR add the missing parameter to the affected calls.
