### PR TITLE
Example.py: allow CoAP port customization and debug logging level

### DIFF
--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -71,14 +71,11 @@ def socket_init(socket_port: int) -> socket.socket:
 class COAP(asyncio.DatagramProtocol):
     """COAP manager."""
 
-    def __init__(
-        self, message_received: Callable | None = None, port: int | None = None
-    ) -> None:
+    def __init__(self, message_received: Callable | None = None) -> None:
         """Initialize COAP manager."""
         self.sock: socket.socket | None = None
         # Will receive all updates
         self._message_received = message_received
-        self._port = port
         self.subscriptions: dict[str, Callable] = {}
         self.transport: asyncio.DatagramTransport | None = None
 
@@ -134,10 +131,7 @@ class COAP(asyncio.DatagramProtocol):
 
     async def __aenter__(self) -> "COAP":
         """Entering async context manager."""
-        if self._port:
-            await self.initialize(self._port)
-        else:
-            await self.initialize()
+        await self.initialize()
         return self
 
     async def __aexit__(

--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -71,11 +71,14 @@ def socket_init(socket_port: int) -> socket.socket:
 class COAP(asyncio.DatagramProtocol):
     """COAP manager."""
 
-    def __init__(self, message_received: Callable | None = None) -> None:
+    def __init__(
+        self, message_received: Callable | None = None, port: int | None = None
+    ) -> None:
         """Initialize COAP manager."""
         self.sock: socket.socket | None = None
         # Will receive all updates
         self._message_received = message_received
+        self._port = port
         self.subscriptions: dict[str, Callable] = {}
         self.transport: asyncio.DatagramTransport | None = None
 
@@ -131,7 +134,10 @@ class COAP(asyncio.DatagramProtocol):
 
     async def __aenter__(self) -> "COAP":
         """Entering async context manager."""
-        await self.initialize()
+        if self._port:
+            await self.initialize(self._port)
+        else:
+            await self.initialize()
         return self
 
     async def __aexit__(

--- a/example.py
+++ b/example.py
@@ -6,8 +6,11 @@ import argparse
 import asyncio
 import json
 import logging
+import signal
+import sys
 import traceback
 from datetime import datetime
+from types import FrameType
 from typing import Any, Tuple, cast
 
 import aiohttp
@@ -24,6 +27,14 @@ from aioshelly.rpc_device import RpcDevice
 async def get_coap_context(port: int) -> COAP:
     """Create CoAP context"""
     context = COAP()
+
+    def handle_sigint(_exit_code: int, _frame: FrameType) -> None:
+        """Handle Keyboard signal interrupt (ctrl-c)."""
+        context.close()
+        sys.exit()
+
+    signal.signal(signal.SIGINT, handle_sigint)
+
     await context.initialize(port)
     return context
 
@@ -271,7 +282,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        pass
+    asyncio.run(main())

--- a/example.py
+++ b/example.py
@@ -65,14 +65,10 @@ async def test_single(
     """Test single device."""
     async with aiohttp.ClientSession() as aiohttp_session:
         try:
+            coap_context = await get_coap_context(port)
             async with async_timeout.timeout(timeout):
                 device = await create_device(
-                    aiohttp_session,
-                    await get_coap_context(port),
-                    options,
-                    init,
-                    timeout,
-                    gen,
+                    aiohttp_session, coap_context, options, init, timeout, gen
                 )
         except asyncio.TimeoutError:
             print("Timeout connecting to", options.ip_address)
@@ -102,12 +98,7 @@ async def test_devices(init: bool, timeout: float, port: int, gen: int | None) -
             *[
                 asyncio.wait_for(
                     connect_and_print_device(
-                        aiohttp_session,
-                        coap_context,
-                        options,
-                        init,
-                        timeout,
-                        gen,
+                        aiohttp_session, coap_context, options, init, timeout, gen
                     ),
                     timeout,
                 )

--- a/example.py
+++ b/example.py
@@ -97,6 +97,7 @@ async def test_devices(init: bool, timeout: float, port: int, gen: int | None) -
             device_options.append(ConnectionOptions(**json.loads(line)))
 
     async with aiohttp.ClientSession() as aiohttp_session:
+        coap_context = await get_coap_context(port)
         results = await asyncio.gather(
             *[
                 asyncio.wait_for(

--- a/example.py
+++ b/example.py
@@ -226,7 +226,7 @@ def get_arguments() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--gen2", "-g2", action="store_true", help="Force Gen 2 (RPC) device"
     )
     parser.add_argument(
-        "--debugger", "-deb", action="store_true", help="Enable debug level for logging"
+        "--debug", "-deb", action="store_true", help="Enable debug level for logging"
     )
 
     arguments = parser.parse_args()

--- a/example.py
+++ b/example.py
@@ -24,9 +24,7 @@ from aioshelly.rpc_device import RpcDevice
 async def get_coap_context(port: int | None = None) -> COAP:
     """Create CoAP context"""
     context = COAP()
-    if not port:
-        port = 5683
-    await context.initialize(port)
+    await context.initialize(port or 5683)
     return context
 
 

--- a/example.py
+++ b/example.py
@@ -103,7 +103,7 @@ async def test_devices(init: bool, timeout: float, port: int, gen: int | None) -
                 asyncio.wait_for(
                     connect_and_print_device(
                         aiohttp_session,
-                        await get_coap_context(port),
+                        coap_context,
                         options,
                         init,
                         timeout,

--- a/example.py
+++ b/example.py
@@ -24,7 +24,7 @@ from aioshelly.rpc_device import RpcDevice
 async def get_coap_context(port: int | None = None) -> COAP:
     """Create CoAP context"""
     context = COAP()
-    await context.initialize(port or 5683)
+    await context.initialize(port)
     return context
 
 
@@ -211,7 +211,11 @@ def get_arguments() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--ip_address", "-ip", type=str, help="Test single device by IP address"
     )
     parser.add_argument(
-        "--socket_port", "-sp", type=int, help="Specify socket UDP port"
+        "--socket_port",
+        "-sp",
+        type=int,
+        default=5683,
+        help="Specify socket UDP port (default=5683)",
     )
     parser.add_argument(
         "--devices",

--- a/example.py
+++ b/example.py
@@ -21,7 +21,7 @@ from aioshelly.exceptions import ShellyError, WrongShellyGen
 from aioshelly.rpc_device import RpcDevice
 
 
-async def get_coap_context(port: int | None = None) -> COAP:
+async def get_coap_context(port: int) -> COAP:
     """Create CoAP context"""
     context = COAP()
     await context.initialize(port)


### PR DESCRIPTION
2 new parameters for example.py:

- "`--socket_port`" : allows CoAP port customization.
- "`--debug`": set debug logging level.
