### PR TITLE
Add full path REST call

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -218,7 +218,7 @@ class BlockDevice:
         if self.options.auth is None and self.requires_auth:
             raise AuthRequired
 
-        _LOGGER.debug("aiohttp request: /%s", path)
+        _LOGGER.debug("aiohttp request: /%s (params=%s)", path, params)
         resp: ClientResponse = await self.aiohttp_session.request(
             method,
             f"http://{self.options.ip_address}/{path}",

--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -407,6 +407,10 @@ class Block:
             "get", f"{self.type}/{self.channel}", kwargs
         )
 
+    async def set_state_full_path(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Set state request (HTTP)."""
+        return await self.device.http_request("get", f"{path}", kwargs)
+
     async def toggle(self) -> dict[str, Any]:
         """Toggle status."""
         return await self.set_state(turn="off" if self.output else "on")


### PR DESCRIPTION
Allow the caller to specify a full REST path (needed for Shelly Valve and Shelly Motion )