### PR TITLE
Add ident to RPC GetDeviceInfo call

### DIFF
--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -126,7 +126,9 @@ class RpcDevice:
 
     async def update_device_info(self) -> None:
         """Get device info from 'Shelly.GetDeviceInfo'."""
-        self._device_info = await self._wsrpc.call("Shelly.GetDeviceInfo")
+        self._device_info = await self._wsrpc.call(
+            "Shelly.GetDeviceInfo", {"ident": True}
+        )
 
     async def update_config(self) -> None:
         """Get device config from 'Shelly.GetConfig'."""


### PR DESCRIPTION
In order to get some more info about the device, the ident `param` is needed.

Reply will then have 2 more keys:

- batch
- key

I think it would be worth to decode key with one of https://jwt.io/libraries?language=Python
Decode content with current firmware looks like:

```json
{
  "iat": 1631078138,
  "mac": "xxxxxxxx",
  "m": "SPSW-004PE16EU",
  "b": "2132-002",
  "fp": "xxxxxx"
}

```
Simone
