### PR TITLE
Fix - prevent setting resolves during disconnect or at startup

### DIFF
--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -148,7 +148,8 @@ class WsRPC:
                 return
 
             call = self._calls.pop(frame_id)
-            call.resolve.set_result(frame)
+            if not call.resolve.cancelled():
+                call.resolve.set_result(frame)
 
         else:
             _LOGGER.warning("Invalid frame: %s", frame)
@@ -162,7 +163,8 @@ class WsRPC:
             except ConnectionClosed:
                 break
 
-            self._handle_frame(frame)
+            if not self._client.closed:
+                self._handle_frame(frame)
 
         _LOGGER.debug("Websocket connection closed")
 


### PR DESCRIPTION
Prevent setting futures resolves during disconnect to prevent the following:
```
2022-01-05 20:05:21 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aioshelly/wsrpc.py", line 165, in _rx_msgs
    self._handle_frame(frame)
  File "/usr/local/lib/python3.9/site-packages/aioshelly/wsrpc.py", line 151, in _handle_frame
    call.resolve.set_result(frame)
asyncio.exceptions.InvalidStateError: invalid state
```
May also happen during startup if we get a response from the device from previous connection.