### PR TITLE
Shelly Motion: enable/disable motion detection support.

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -268,6 +268,12 @@ class BlockDevice:
         """Trigger a Shelly Gas unmute action."""
         await self.http_request("get", "unmute")
 
+    async def set_shelly_motion_detection(self, enable: bool) -> None:
+        """Enable or disable Shelly Motion motion detection."""
+        params = {"motion_enable": "true"} if enable else {"motion_enable": "false"}
+
+        await self.http_request("get", "settings", params)
+
     @property
     def requires_auth(self) -> bool:
         """Device check for authentication."""


### PR DESCRIPTION
Hi. I am missing some nice features for Shelly devices in Home Assistant, e.g. enabling/disabling Shelly Motion motion detection, setting motion/tamper sensitivity, or changing Shelly Gas Valve addon state. I would like to contribute those to aioshelly and Home Assistant Core. I created this small PR to get a feedback and see the whole process. Thank you.