### PR TITLE
shelly gen2 auth support

### DIFF
--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -22,7 +22,6 @@ def mergedicts(dict1: dict, dict2: dict) -> dict:
     return result
 
 
-
 class RpcDevice:
     """Shelly RPC device reppresentation."""
 
@@ -89,20 +88,12 @@ class RpcDevice:
         try:
             self.shelly = await get_info(self.aiohttp_session, self.options.ip_address)
 
-            if self.options.auth or not self.requires_auth:
-                await self._wsrpc.connect(self.aiohttp_session, self.options)
-                await asyncio.gather(
-                    self.update_device_info(),
-                    self.update_config(),
-                    self.update_status(),
-                )
-            elif self.requires_auth:
-                await self._wsrpc.connect(self.aiohttp_session, self.options.password)
-                await asyncio.gather(
-                    self.update_device_info(),
-                    self.update_config(),
-                    self.update_status(),
-                )
+            await self._wsrpc.connect(self.aiohttp_session, self.options)
+            await asyncio.gather(
+                self.update_device_info(),
+                self.update_config(),
+                self.update_status(),
+            )
             self.initialized = True
         finally:
             self._initializing = False

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Callable, cast
 
+import hashlib
+import json
+import secrets
+
 import aiohttp
 from aiohttp.client import ClientSession
 
 from .common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
-from .exceptions import AuthRequired, NotInitialized, WrongShellyGen
+from .exceptions import AuthRequired, NotInitialized, WrongShellyGen, JSONRPCError
 from .wsrpc import WsRPC
 
 
@@ -20,6 +24,10 @@ def mergedicts(dict1: dict, dict2: dict) -> dict:
         if isinstance(value, dict) and isinstance(dict1.get(key), dict):
             result[key] = mergedicts(dict1[key], value)
     return result
+
+
+def sha256(message):
+    return hashlib.sha256(message.encode('utf-8')).hexdigest()
 
 
 class RpcDevice:
@@ -95,6 +103,40 @@ class RpcDevice:
                     self.update_config(),
                     self.update_status(),
                 )
+            elif self.requires_auth:
+                try:
+                    await self._wsrpc.connect(self.aiohttp_session)
+                    result = await self._wsrpc.call("Sys.GetStatus", {})
+                except JSONRPCError as err:
+                    if err.code == 401:
+                        response_message = json.loads(err.message)
+
+                        username = "admin" #always
+                        password = "super-secret"
+                        ha1 = sha256(f"{username}:{response_message['realm']}:{password}")
+                        # Static noise
+                        ha2 = sha256("dummy_method:dummy_uri")
+                        cnonce = secrets.randbelow(10**8)
+                        if "nc" not in response_message:
+                            response_message['nc'] = 1
+                        hashed = sha256(f"{ha1}:{response_message['nonce']}:{response_message['nc']}:{cnonce}:auth:{ha2}")
+                        auth = {
+                                "realm": response_message["realm"],
+                                "username": "admin",
+                                "nonce": response_message["nonce"],
+                                "cnonce": cnonce,
+                                "response": hashed,
+                                "algorithm": "SHA-256"
+                        }
+                        self._wsrpc.set_auth(auth)
+                        # Verify auth
+                        try:
+                            new_result = await self._wsrpc.call("Sys.GetStatus")
+                        except JSONRPCError as err:
+                            print("Auth still failed, password may be incorrect")
+                            raise err
+                    else:
+                        raise err
             self.initialized = True
         finally:
             self._initializing = False

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import pprint
+import hashlib
+import json
+import secrets
 from asyncio import tasks
 from dataclasses import dataclass
 from typing import Any, Callable, cast
@@ -12,6 +15,7 @@ import aiohttp
 import async_timeout
 from aiohttp import ClientWebSocketResponse, WSMsgType, client_exceptions
 
+from .common import ConnectionOptions
 from .const import NOTIFY_WS_CLOSED, WS_HEARTBEAT
 from .exceptions import (
     CannotConnect,
@@ -65,6 +69,9 @@ class RPCCall:
         return msg
 
 
+def hex_hash(message):
+    return hashlib.sha256(message.encode('utf-8')).hexdigest()
+
 class WsRPC:
     """WsRPC class."""
 
@@ -84,7 +91,7 @@ class WsRPC:
         self._call_id += 1
         return self._call_id
 
-    async def connect(self, aiohttp_session: aiohttp.ClientSession) -> None:
+    async def connect(self, aiohttp_session: aiohttp.ClientSession, password: str = "") -> None:
         """Connect to device."""
         if self.connected:
             raise RuntimeError("Already connected")
@@ -103,6 +110,41 @@ class WsRPC:
         self._rx_task = asyncio.create_task(self._rx_msgs())
 
         _LOGGER.info("Connected to %s", self._ip_address)
+
+        # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
+        if password:
+            try:
+                result = await self.call("Sys.GetStatus", {})
+            except JSONRPCError as err:
+                if err.code == 401:
+                    response_message = json.loads(err.message)
+
+                    username = "admin" #always
+                    ha1 = hex_hash(f"{username}:{response_message['realm']}:{password}")
+                    # Static noise
+                    ha2 = hex_hash("dummy_method:dummy_uri")
+                    cnonce = secrets.randbelow(10**8)
+                    if "nc" not in response_message:
+                        response_message['nc'] = 1
+                    hashed = hex_hash(f"{ha1}:{response_message['nonce']}:{response_message['nc']}:{cnonce}:auth:{ha2}")
+                    auth = {
+                            "realm": response_message["realm"],
+                            "username": "admin",
+                            "nonce": response_message["nonce"],
+                            "cnonce": cnonce,
+                            "response": hashed,
+                            "algorithm": "SHA-256"
+                    }
+                    self.set_auth(auth)
+                    # Verify auth
+                    try:
+                        new_result = await self.call("Sys.GetStatus")
+                    except JSONRPCError as err:
+                        _LOGGER.info("Auth failed, password may be incorrect")
+                        raise err
+                else:
+                    raise err
+
 
     async def disconnect(self) -> None:
         """Disconnect all sessions."""

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-import pprint
 import hashlib
 import json
+import logging
+import pprint
 import secrets
 from asyncio import tasks
 from dataclasses import dataclass

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -42,16 +42,23 @@ class RPCCall:
     """RPCCall class."""
 
     def __init__(
-        self, call_id: int, method: str, params: dict[str, Any], auth: dict[str, Any] | None, route: RouteData
+        self,
+        call_id: int,
+        method: str,
+        params: dict[str, Any] | None,
+        route: RouteData,
     ):
         """Initialize RPC class."""
         self.call_id = call_id
-        self.params = params
-        self.auth = auth
         self.method = method
+        self.params = params
         self.src = route.src
         self.dst = route.dst
         self.resolve: asyncio.Future = asyncio.Future()
+        self.auth = {}
+        if params and "auth" in params:
+            self.auth = params["auth"]
+            del params["auth"]
 
     @property
     def request_frame(self) -> dict[str, Any]:
@@ -69,8 +76,12 @@ class RPCCall:
         return msg
 
 
-def hex_hash(message):
-    return hashlib.sha256(message.encode('utf-8')).hexdigest()
+def hex_hash(message: str) -> str:
+    """
+    Get hex representation of sha256 hash of string
+    """
+    return hashlib.sha256(message.encode("utf-8")).hexdigest()
+
 
 class WsRPC:
     """WsRPC class."""
@@ -78,7 +89,7 @@ class WsRPC:
     def __init__(self, ip_address: str, on_notification: Callable) -> None:
         """Initialize WsRPC class."""
         self._ip_address = ip_address
-        self._auth = {}
+        self._auth: dict[str, Any] = {}
         self._on_notification = on_notification
         self._rx_task: tasks.Task[None] | None = None
         self._client: ClientWebSocketResponse | None = None
@@ -91,7 +102,11 @@ class WsRPC:
         self._call_id += 1
         return self._call_id
 
-    async def connect(self, aiohttp_session: aiohttp.ClientSession, options: ConnectionOptions | None = None) -> None:
+    async def connect(
+        self,
+        aiohttp_session: aiohttp.ClientSession,
+        options: ConnectionOptions | None = None,
+    ) -> None:
         """Connect to device."""
         if self.connected:
             raise RuntimeError("Already connected")
@@ -114,37 +129,40 @@ class WsRPC:
         # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
         if options and options.password:
             try:
-                result = await self.call("Sys.GetStatus", {})
+                # First API call should fail with 401 if auth enabled
+                await self.call("Sys.GetStatus", {})
             except JSONRPCError as err:
-                if err.code == 401:
-                    response_message = json.loads(err.message)
-
-                    username = "admin" #always
-                    ha1 = hex_hash(f"{username}:{response_message['realm']}:{options.password}")
-                    # Static noise
-                    ha2 = hex_hash("dummy_method:dummy_uri")
-                    cnonce = secrets.randbelow(10**8)
-                    if "nc" not in response_message:
-                        response_message['nc'] = 1
-                    hashed = hex_hash(f"{ha1}:{response_message['nonce']}:{response_message['nc']}:{cnonce}:auth:{ha2}")
-                    auth = {
-                            "realm": response_message["realm"],
-                            "username": "admin",
-                            "nonce": response_message["nonce"],
-                            "cnonce": cnonce,
-                            "response": hashed,
-                            "algorithm": "SHA-256"
-                    }
-                    self.set_auth(auth)
-                    # Verify auth
-                    try:
-                        await self.call("Sys.GetStatus")
-                    except JSONRPCError as err:
-                        _LOGGER.info("Auth failed, password may be incorrect")
-                        raise err
-                else:
+                if err.code != 401:
                     raise err
+                response_message = json.loads(err.message)
 
+                username = "admin"  # always
+                ha1 = hex_hash(
+                    f"{username}:{response_message['realm']}:{options.password}"
+                )
+                # Static noise
+                ha2 = hex_hash("dummy_method:dummy_uri")
+                cnonce = secrets.randbelow(10**8)
+                if "nc" not in response_message:
+                    response_message["nc"] = 1
+                hashed = hex_hash(
+                    f"{ha1}:{response_message['nonce']}:{response_message['nc']}:{cnonce}:auth:{ha2}"
+                )
+                auth = {
+                    "realm": response_message["realm"],
+                    "username": "admin",
+                    "nonce": response_message["nonce"],
+                    "cnonce": cnonce,
+                    "response": hashed,
+                    "algorithm": "SHA-256",
+                }
+                self.set_auth(auth)
+                # Verify auth
+                try:
+                    await self.call("Sys.GetStatus")
+                except JSONRPCError as err:
+                    _LOGGER.info("Auth failed, password may be incorrect")
+                    raise err
 
     async def disconnect(self) -> None:
         """Disconnect all sessions."""
@@ -252,7 +270,10 @@ class WsRPC:
         """Return if we're currently connected."""
         return self._client is not None and not self._client.closed
 
-    def set_auth(self, auth):
+    def set_auth(self, auth: dict[str, Any]) -> None:
+        """
+        Sets digest auth params
+        """
         self._auth = auth
 
     async def call(
@@ -262,7 +283,12 @@ class WsRPC:
         if self._client is None:
             raise RuntimeError("Not connected")
 
-        call = RPCCall(self._next_id, method, params, self._auth, self._route)
+        if self._auth:
+            if not params:
+                params = {}
+            if "auth" not in params:
+                params["auth"] = self._auth
+        call = RPCCall(self._next_id, method, params, self._route)
         self._calls[call.call_id] = call
         await self._client.send_json(call.request_frame)
 

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -91,7 +91,7 @@ class WsRPC:
         self._call_id += 1
         return self._call_id
 
-    async def connect(self, aiohttp_session: aiohttp.ClientSession, password: str = "") -> None:
+    async def connect(self, aiohttp_session: aiohttp.ClientSession, options: ConnectionOptions | None = None) -> None:
         """Connect to device."""
         if self.connected:
             raise RuntimeError("Already connected")
@@ -112,7 +112,7 @@ class WsRPC:
         _LOGGER.info("Connected to %s", self._ip_address)
 
         # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
-        if password:
+        if options and options.password:
             try:
                 result = await self.call("Sys.GetStatus", {})
             except JSONRPCError as err:

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -120,7 +120,7 @@ class WsRPC:
                     response_message = json.loads(err.message)
 
                     username = "admin" #always
-                    ha1 = hex_hash(f"{username}:{response_message['realm']}:{password}")
+                    ha1 = hex_hash(f"{username}:{response_message['realm']}:{options.password}")
                     # Static noise
                     ha2 = hex_hash("dummy_method:dummy_uri")
                     cnonce = secrets.randbelow(10**8)

--- a/aioshelly/wsrpc.py
+++ b/aioshelly/wsrpc.py
@@ -138,7 +138,7 @@ class WsRPC:
                     self.set_auth(auth)
                     # Verify auth
                     try:
-                        new_result = await self.call("Sys.GetStatus")
+                        await self.call("Sys.GetStatus")
                     except JSONRPCError as err:
                         _LOGGER.info("Auth failed, password may be incorrect")
                         raise err


### PR DESCRIPTION
This PR provides some of the logic needed to support Shelly gen2 digest authentication for websocket connections. See original issue at https://github.com/home-assistant/core/issues/63621

References:

- [Shelly docs on digest auth](https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket)
- [typescript implementation](https://github.com/ALLTERCO/gen2-sample-code/blob/main/http-digest-auth/src/shellyHttpCall.ts)

I'm not super familiar with the structure of the rest of the codebase, so there's probably a lot here that needs to be restructured.

Anyway, the following code is what I used to verify that authentication is working for a local device


```python
import asyncio
from pprint import pprint

import aiohttp
import async_timeout

from aioshelly.common import ConnectionOptions
from aioshelly.rpc_device import RpcDevice


async def test_rpc_device():
    """Test Gen2 RPC (WebSocket) based device."""
    shelly_ip = "192.168.33.1"
    api_url = f"http://{shelly_ip}/rpc/Switch.Toggle?id=0"
    options = ConnectionOptions(shelly_ip, password="super-secret")

    async with aiohttp.ClientSession() as aiohttp_session:
        try:
            async with async_timeout.timeout(10):
                #device = await WsRPC.connect(aiohttp_session, options)
                device = await RpcDevice.create(aiohttp_session, options)
        except asyncio.TimeoutError:
            print("Timeout connecting to", ConnectionOptions.ip_address)
            return

        method = "Switch.Toggle"
        params = {"id": 0}
        response = await device.call_rpc(method, params)
        pprint("toggle response:")
        pprint(response)


if __name__ == "__main__":
    asyncio.run(test_rpc_device())
```