### PR TITLE
Bump version to 1.0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open("README.md").read()
 
 setup(
     name="aioshelly",
-    version="1.0.9",
+    version="1.0.10",
     license="Apache License 2.0",
     url="https://github.com/home-assistant-libs/aioshelly",
     author="Paulus Schoutsen",


### PR DESCRIPTION
On the release notes for this version we add the following text:
## Last release with support for Python 3.8, future releases will require Python 3.9+


