### PR TITLE
Add breaking change section to release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,7 @@
 categories:
+  - title: "⚠ Breaking Changes"
+    labels:
+      - "breaking-change"
   - title: "⬆️ Dependencies"
     collapse-after: 1
     labels:


### PR DESCRIPTION
Add `breaking-change` section to release drafter, similar to core repository and other repositories in `home-assistant-libs`