### PR TITLE
Pad CoAP request with 0x00 to fix Hyper-V issue due to KB5015807

### DIFF
--- a/aioshelly/coap.py
+++ b/aioshelly/coap.py
@@ -91,7 +91,7 @@ class COAP(asyncio.DatagramProtocol):
         Subscribe with `subscribe_updates` to receive answer.
         """
         assert self.transport is not None
-        msg = b"\x50\x01\x00\x0A\xb3cit\x01" + path.encode() + b"\xFF"
+        msg = b"\x50\x01\x00\x0A\xb3cit\x01" + path.encode() + b"\xFF\x00"
         _LOGGER.debug("Sending request 'cit/%s' to device %s", path, ip)
         self.transport.sendto(msg, (ip, 5683))
 


### PR DESCRIPTION
**Pad outgoing CoAP requests with 0x00.** 

In KB5015807 (Windows 10) or KB5015814 (Windows 11) a bug introduced by Microsoft causing Hyper-V to drop UDP packets with payload less than 12 bytes. `aioshelly` uses 11 bytes for the `cit/d` request which gets dropped.

Although this is not identified as bug in `aioshelly`, but since it affects large number of installation becoming non operational and some users having trouble to remove the update as it is marked as a security update, this workaround does not have any negative affect as the addional pad with `\x00` (null) does not break the CoAP protocol.

Duo to the importance of this fix I have verified it over 24 Gen1 Shelly models out of 30 active models.

Core related issue: https://github.com/home-assistant/core/issues/75118
