### PR TITLE
Add inbound websocket server for Gen2 sleeping devices

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -7,11 +7,11 @@ from typing import Any, Callable, cast
 
 import aiohttp
 import async_timeout
-from aiohttp.client_reqrep import ClientResponse
+from aiohttp.client import ClientResponse
 
 from .coap import COAP, CoapMessage
 from .common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
-from .const import BLOCK_DEVICE_INIT_TIMEOUT, HTTP_CALL_TIMEOUT
+from .const import DEVICE_INIT_TIMEOUT, HTTP_CALL_TIMEOUT
 from .exceptions import AuthRequired, NotInitialized, WrongShellyGen
 
 BLOCK_VALUE_UNIT = "U"
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BlockDevice:
-    """Shelly block device reppresentation."""
+    """Shelly block device representation."""
 
     def __init__(
         self,
@@ -124,7 +124,7 @@ class BlockDevice:
     async def _async_init(self) -> None:
         """Async init upon CoAP message event."""
         try:
-            async with async_timeout.timeout(BLOCK_DEVICE_INIT_TIMEOUT):
+            async with async_timeout.timeout(DEVICE_INIT_TIMEOUT):
                 await self.initialize()
         except (asyncio.TimeoutError, OSError) as err:
             _LOGGER.warning(

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -71,8 +71,8 @@ MODEL_NAMES = {
     "SPSW-202XE16EU": "Shelly Pro 2",
 }
 
-# Timeout used for Block Device init
-BLOCK_DEVICE_INIT_TIMEOUT = 10
+# Timeout used for Device init
+DEVICE_INIT_TIMEOUT = 10
 
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10


### PR DESCRIPTION
## Add websocket server to enable Shelly Gen2 sleeping devices to send back data.

This PR copy most of the logic we use in CoAP for Gen1:
- Single server with shared context
- Init device upon receiving a message from the device
- Subscribe for push updates by device IP

To test this on a sleeping device:
- In the device web under `Networks` -> `Outbound websocket` enable the outbound websocket and set URL that points to the host: `ws://<host_ip>:5683/` (note that the `/` at the end is mandatory)
- Run the example : `example.py --ip <device_ip> -g2`
Wait for an update or push the button on the device (when pushing back to sleep device also sends an update)

## Breaking change
`RpcDevice.create` requires an additional parameter for the shared inbound websocket server

When creating a device the following:
```python
RpcDevice.create(aiohttp_session, options, init)
```
Should be changed to:
```python
ws_context = WsServer()
await ws_context.initialize(ws_port)
RpcDevice.create(aiohttp_session, ws_context, options, init)
```
