### PR TITLE
Handle exceptions and timeouts inside aioshelly

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1,4 +1,19 @@
 """Constants for aioshelly."""
+import asyncio
+
+import aiohttp
+
+from .exceptions import DeviceConnectionError, JSONRPCError, RPCError, RPCTimeout
+
+CONNECT_ERRORS = (
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+    DeviceConnectionError,
+    OSError,
+    RPCError,
+    RPCTimeout,
+    JSONRPCError,
+)
 
 MODEL_NAMES = {
     # Gen1 CoAP based models
@@ -71,8 +86,8 @@ MODEL_NAMES = {
     "SPSW-202XE16EU": "Shelly Pro 2",
 }
 
-# Timeout used for Device init
-DEVICE_INIT_TIMEOUT = 10
+# Timeout used for Device IO
+DEVICE_IO_TIMEOUT = 10
 
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10
@@ -83,7 +98,7 @@ GEN1_MIN_FIRMWARE_DATE = 20200812
 # Firmware 0.8.1 release date
 GEN2_MIN_FIRMWARE_DATE = 20210921
 
-# Notification sent by RPC device in case of WebSocket close
-NOTIFY_WS_CLOSED = "NotifiyWebSocketClosed"
-
 WS_HEARTBEAT = 55
+
+# Default Gen2 outbound websocket API URL
+WS_API_URL = "/api/shelly/ws"

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -1,29 +1,13 @@
 """Shelly exceptions."""
 from __future__ import annotations
 
+# Internal or run time errors:
+#    Errors not needed to be handled by the caller
+#    'NotInitialized' & 'WrongShellyGen' indicate runtime errors
+
 
 class ShellyError(Exception):
     """Base class for aioshelly errors."""
-
-
-class AuthRequired(ShellyError):
-    """Raised during initialization if auth is required but not given."""
-
-
-class NotInitialized(ShellyError):
-    """Raised if device is not initialized."""
-
-
-class FirmwareUnsupported(ShellyError):
-    """Raised if device firmware version is unsupported."""
-
-
-class CannotConnect(ShellyError):
-    """Exception raised when failed to connect the client."""
-
-
-class ConnectionFailed(ShellyError):
-    """Exception raised when a connection failed."""
 
 
 class ConnectionClosed(ShellyError):
@@ -52,9 +36,25 @@ class JSONRPCError(RPCError):
         super().__init__(code, message)
 
 
-class InvalidAuthError(JSONRPCError):
-    """Raised to indicate invalid authentication error."""
+class NotInitialized(ShellyError):
+    """Raised if device is not initialized."""
 
 
 class WrongShellyGen(ShellyError):
     """Exception raised to indicate wrong Shelly generation."""
+
+
+# Errors to be handled by the caller:
+#    Errors that are expected to happen and should be handled by the caller.
+
+
+class DeviceConnectionError(ShellyError):
+    """Exception indicates device connection errors."""
+
+
+class FirmwareUnsupported(ShellyError):
+    """Raised if device firmware version is unsupported."""
+
+
+class InvalidAuthError(ShellyError):
+    """Raised to indicate invalid or missing authentication error."""

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -147,8 +147,9 @@ class RpcDevice:
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            await self.shutdown()
-            raise DeviceConnectionError(err) from err
+            if not async_init:
+                await self.shutdown()
+                raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
 

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -10,8 +10,14 @@ import async_timeout
 from aiohttp.client import ClientSession
 
 from .common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
-from .const import DEVICE_INIT_TIMEOUT
-from .exceptions import AuthRequired, NotInitialized, WrongShellyGen
+from .const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT
+from .exceptions import (
+    DeviceConnectionError,
+    InvalidAuthError,
+    NotInitialized,
+    ShellyError,
+    WrongShellyGen,
+)
 from .wsrpc import WsRPC, WsServer
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,15 +48,15 @@ class RpcDevice:
         self.shelly: dict[str, Any] | None = None
         self._status: dict[str, Any] | None = None
         self._event: dict[str, Any] | None = None
-        self._device_info: dict[str, Any] | None = None
         self._config: dict[str, Any] | None = None
         self._wsrpc = WsRPC(options.ip_address, self._on_notification)
-        self._unsub_listening = ws_context.subscribe_updates(
+        self._unsub_ws: Callable | None = ws_context.subscribe_updates(
             options.ip_address, self._wsrpc.handle_frame
         )
         self._update_listener: Callable | None = None
         self.initialized: bool = False
         self._initializing: bool = False
+        self._last_error: ShellyError | None = None
 
     @classmethod
     async def create(
@@ -71,14 +77,8 @@ class RpcDevice:
 
     async def _async_init(self) -> None:
         """Async init upon WsRPC message event."""
-        try:
-            async with async_timeout.timeout(DEVICE_INIT_TIMEOUT):
-                await self.initialize()
-                await self._wsrpc.disconnect()
-        except (asyncio.TimeoutError, OSError) as err:
-            _LOGGER.warning(
-                "device %s initialize error - %s", self.options.ip_address, repr(err)
-            )
+        await self.initialize(True)
+        await self._wsrpc.disconnect()
 
     def _on_notification(
         self, method: str, params: dict[str, Any] | None = None
@@ -87,7 +87,6 @@ class RpcDevice:
         if not self._initializing and not self.initialized:
             loop = asyncio.get_running_loop()
             loop.create_task(self._async_init())
-            return
 
         if params is not None:
             if method == "NotifyFullStatus":
@@ -107,19 +106,20 @@ class RpcDevice:
         """Device ip address."""
         return self.options.ip_address
 
-    async def initialize(self) -> None:
+    async def initialize(self, async_init: bool = False) -> None:
         """Device initialization."""
         if self._initializing:
             raise RuntimeError("Already initializing")
 
         self._initializing = True
         self.initialized = False
+        ip = self.options.ip_address
         try:
             self.shelly = await get_info(self.aiohttp_session, self.options.ip_address)
 
             if self.requires_auth:
                 if self.options.username is None or self.options.password is None:
-                    raise AuthRequired
+                    raise InvalidAuthError("auth missing and required")
 
                 self._wsrpc.set_auth_data(
                     self.shelly["auth_domain"],
@@ -127,13 +127,28 @@ class RpcDevice:
                     self.options.password,
                 )
 
-            await self._wsrpc.connect(self.aiohttp_session)
-            await asyncio.gather(
-                self.update_device_info(),
-                self.update_config(),
-                self.update_status(),
-            )
+            async with async_timeout.timeout(DEVICE_IO_TIMEOUT):
+                await self._wsrpc.connect(self.aiohttp_session)
+                await self.update_config()
+
+                if not async_init:
+                    await self.update_status()
+
             self.initialized = True
+        except InvalidAuthError as err:
+            self._last_error = InvalidAuthError(err)
+            _LOGGER.debug("host %s: error: %r", ip, self._last_error)
+            # Auth error during async init, used by sleeping devices
+            # Will raise 'invalidAuthError' on next property read
+            if not async_init:
+                await self.shutdown()
+                raise
+            self.initialized = True
+        except CONNECT_ERRORS as err:
+            self._last_error = DeviceConnectionError(err)
+            _LOGGER.debug("host %s: error: %r", ip, self._last_error)
+            await self.shutdown()
+            raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
 
@@ -143,7 +158,11 @@ class RpcDevice:
     async def shutdown(self) -> None:
         """Shutdown device."""
         self._update_listener = None
-        self._unsub_listening()
+
+        if self._unsub_ws:
+            self._unsub_ws()
+            self._unsub_ws = None
+
         await self._wsrpc.disconnect()
 
     def subscribe_updates(self, update_listener: Callable) -> None:
@@ -153,23 +172,19 @@ class RpcDevice:
     async def trigger_ota_update(self, beta: bool = False) -> None:
         """Trigger an ota update."""
         params = {"stage": "beta"} if beta else {"stage": "stable"}
-        await self._wsrpc.call("Shelly.Update", params)
+        await self.call_rpc("Shelly.Update", params)
 
     async def trigger_reboot(self) -> None:
         """Trigger a device reboot."""
-        await self._wsrpc.call("Shelly.Reboot")
+        await self.call_rpc("Shelly.Reboot")
 
     async def update_status(self) -> None:
         """Get device status from 'Shelly.GetStatus'."""
-        self._status = await self._wsrpc.call("Shelly.GetStatus")
-
-    async def update_device_info(self) -> None:
-        """Get device info from 'Shelly.GetDeviceInfo'."""
-        self._device_info = await self._wsrpc.call("Shelly.GetDeviceInfo")
+        self._status = await self.call_rpc("Shelly.GetStatus")
 
     async def update_config(self) -> None:
         """Get device config from 'Shelly.GetConfig'."""
-        self._config = await self._wsrpc.call("Shelly.GetConfig")
+        self._config = await self.call_rpc("Shelly.GetConfig")
 
     @property
     def requires_auth(self) -> bool:
@@ -182,10 +197,18 @@ class RpcDevice:
         return bool(self.shelly["auth_en"])
 
     async def call_rpc(
-        self, method: str, params: dict[str, Any] | None
+        self, method: str, params: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Call RPC method."""
-        return await self._wsrpc.call(method, params)
+        try:
+            async with async_timeout.timeout(DEVICE_IO_TIMEOUT):
+                return await self._wsrpc.call(method, params)
+        except InvalidAuthError as err:
+            self._last_error = InvalidAuthError(err)
+            raise
+        except CONNECT_ERRORS as err:
+            self._last_error = DeviceConnectionError(err)
+            raise DeviceConnectionError from err
 
     @property
     def status(self) -> dict[str, Any]:
@@ -194,7 +217,7 @@ class RpcDevice:
             raise NotInitialized
 
         if self._status is None:
-            raise AuthRequired
+            raise InvalidAuthError
 
         return self._status
 
@@ -207,24 +230,13 @@ class RpcDevice:
         return self._event
 
     @property
-    def device_info(self) -> dict[str, Any]:
-        """Get device info."""
-        if not self.initialized:
-            raise NotInitialized
-
-        if self._device_info is None:
-            raise AuthRequired
-
-        return self._device_info
-
-    @property
     def config(self) -> dict[str, Any]:
         """Get device config."""
         if not self.initialized:
             raise NotInitialized
 
         if self._config is None:
-            raise AuthRequired
+            raise InvalidAuthError
 
         return self._config
 
@@ -256,9 +268,19 @@ class RpcDevice:
     @property
     def hostname(self) -> str:
         """Device hostname."""
-        return cast(str, self.device_info["id"])
+        assert self.shelly
+
+        if not self.initialized:
+            raise NotInitialized
+
+        return cast(str, self.shelly["id"])
 
     @property
     def connected(self) -> bool:
         """Return true if device is connected."""
         return self._wsrpc.connected
+
+    @property
+    def last_error(self) -> ShellyError | None:
+        """Return the last error during async device init."""
+        return self._last_error


### PR DESCRIPTION
## Breaking change

### Removed exceptions
The following exceptions are no longer raised: 
- `AuthRequired`, use `InvalidAuthError` instead
- `CannotConnect`, `ConnectionFailed`, use `DeviceConnectionError` instead

### New exception
```python
Use class DeviceConnectionError(ShellyError):
    """Exception indicates device connection errors.""" instead
```
Raised for any device connection related error, one of the following:
```
CONNECT_ERRORS = (
    aiohttp.ClientError,
    asyncio.TimeoutError,
    OSError,
    RPCError,
    RPCTimeout,
    JSONRPCError,
)
```
They are not needed to be handled upstream anymore.

### Removed
`coap_request` is changed to private (`_coap_request`) this method is not protected by timeout and should not be acceded upstream directly.

Remove default port and update default websocket URL for `WsServer` initialize method.

## Proposed change
Move the exceptions and timeout logic into `aioshelly`, instead of having to catch different OS errors and client responses the library now handle these errors internally and only the following errors should be handled by Shelly integration:
```python
class DeviceConnectionError(ShellyError):
    """Exception indicates device connection errors."""


class FirmwareUnsupported(ShellyError):
    """Raised if device firmware version is unsupported."""


class InvalidAuthError(ShellyError):
    """Raised to indicate invalid or missing authentication error.""
```

For sleeping devices we init the device on a background task and can't raise `InvalidAuthError`, the `InvalidAuthError` is raised when a sleeping device try to access an attribute which needs pulling `settings` (Gen1) or `config1` (Gen2) from the device. This is currently only needed for `Shelly TRV` (climate platform).

In order to address comment by @MartinHjelmare https://github.com/home-assistant-libs/aioshelly/pull/254#discussion_r979256174 `last_error` is stored in the device class and we can include this in diagnostics, this will also help for simple cases such as a `turn on` command failure, currently we ask for debug logs, this can help to have the last failure in the diagnostics.

`example.py` script updated to demonstrate these changes.

PR to test changes in vs Home Assistant Shelly integration: https://github.com/home-assistant-libs/aioshelly/pull/263