### PR TITLE
Add RpcCallError exception

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -3,16 +3,13 @@ import asyncio
 
 import aiohttp
 
-from .exceptions import DeviceConnectionError, JSONRPCError, RPCError, RPCTimeout
+from .exceptions import DeviceConnectionError
 
 CONNECT_ERRORS = (
     aiohttp.ClientError,
     asyncio.TimeoutError,
     DeviceConnectionError,
     OSError,
-    RPCError,
-    RPCTimeout,
-    JSONRPCError,
 )
 
 MODEL_NAMES = {

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -18,24 +18,6 @@ class InvalidMessage(ShellyError):
     """Exception raised when an invalid message is received."""
 
 
-class RPCError(ShellyError):
-    """Base class for RPC errors."""
-
-
-class RPCTimeout(RPCError):
-    """Raised upon RPC call timeout."""
-
-
-class JSONRPCError(RPCError):
-    """Raised during RPC JSON parsing errors."""
-
-    def __init__(self, code: int, message: str = ""):
-        """Initialize JSON RPC errors."""
-        self.code = code
-        self.message = message
-        super().__init__(code, message)
-
-
 class NotInitialized(ShellyError):
     """Raised if device is not initialized."""
 
@@ -58,3 +40,13 @@ class FirmwareUnsupported(ShellyError):
 
 class InvalidAuthError(ShellyError):
     """Raised to indicate invalid or missing authentication error."""
+
+
+class RpcCallError(ShellyError):
+    """Raised to indicate errors in RPC call."""
+
+    def __init__(self, code: int, message: str = ""):
+        """Initialize JSON RPC errors."""
+        self.code = code
+        self.message = message
+        super().__init__(code, message)

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -15,6 +15,7 @@ from .exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
     NotInitialized,
+    RpcCallError,
     ShellyError,
     WrongShellyGen,
 )
@@ -144,7 +145,7 @@ class RpcDevice:
                 await self.shutdown()
                 raise
             self.initialized = True
-        except CONNECT_ERRORS as err:
+        except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
             if not async_init:
@@ -204,8 +205,8 @@ class RpcDevice:
         try:
             async with async_timeout.timeout(DEVICE_IO_TIMEOUT):
                 return await self._wsrpc.call(method, params)
-        except InvalidAuthError as err:
-            self._last_error = InvalidAuthError(err)
+        except (InvalidAuthError, RpcCallError) as err:
+            self._last_error = err
             raise
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)


### PR DESCRIPTION
Noted by @kzyapkov, if the RPC call contains wrong/incomplete parameters or device could not execute the call for some reason but managed to reply back we have no reason to destroy the connection with the device.

This PR adds a new exception `RpcCallError` which will be raised upon failures to `call_rpc`, However during device initialization if the there is a failure, `DeviceConnectionError` is still raised since in this case this is not due to user or parameter error and we can't continue the device initialization.
