### PR TITLE
Add set thermostat state (Shelly TRV)

### DIFF
--- a/aioshelly/block_device.py
+++ b/aioshelly/block_device.py
@@ -318,6 +318,10 @@ class BlockDevice:
 
         await self.http_request("get", "settings", params)
 
+    async def set_thermostat_state(self, channel: int = 0, **kwargs: Any) -> None:
+        """Set thermostat state (Shelly TRV)."""
+        await self.http_request("get", f"thermostat/{channel}", kwargs)
+
     @property
     def requires_auth(self) -> bool:
         """Device check for authentication."""

--- a/pylintrc
+++ b/pylintrc
@@ -28,6 +28,7 @@ disable=
   duplicate-code,
   inconsistent-return-statements,
   too-many-instance-attributes,
+  too-many-public-methods,
   wrong-import-order,
   too-few-public-methods
 


### PR DESCRIPTION
Add method to set thermostat state (Shelly TRV), to avoid using direct HTTP request in Home Assistant