### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.2.0
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
@@ -14,7 +14,7 @@ repos:
           - --quiet
         files: ^(aioshelly/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.17.1
+    rev: v2.2.2
     hooks:
       - id: codespell
         args:
@@ -35,7 +35,7 @@ repos:
           - --max-complexity=18
           - --select=B,C,E,F,W,T4,B9
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
+    rev: 1.7.4
     hooks:
       - id: bandit
         args:
@@ -43,8 +43,8 @@ repos:
           - --format=custom
           - --configfile=bandit.yaml
         files: ^aioshelly/.+\.py$
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
       - id: isort
         args:
@@ -54,7 +54,7 @@ repos:
           - --use-parentheses
           - --line-width=88
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
@@ -71,16 +71,16 @@ repos:
     hooks:
       - id: pydocstyle
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.24.2
+    rev: v1.28.0
     hooks:
       - id: yamllint
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
     hooks:
       - id: prettier
         stages: [manual]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.930"
+    rev: "v0.982"
     hooks:
       - id: mypy
         files: ^aioshelly/.+\.py$


### PR DESCRIPTION
- Bump pre-commit dependencies to latest ones
- Update `isort` repo which was using an archived repository
- Update `prettier` repository to the correct one: https://github.com/pre-commit/mirrors-prettier#using-prettier-with-pre-commit
