### PR TITLE
Add async_ensure_ble_enabled  nd underlying ble_setconfig/ble_getconfig apis

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -107,7 +107,7 @@ def parse_ble_scan_result_event(
 async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
     """Ensure BLE is enabled.
 
-    Returns True if the device needs to be restarted.
+    Returns True if the device was restarted.
 
     Raises RpcCallError if BLE is not supported or could not
     be enabled.
@@ -117,5 +117,7 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
         return False
     ble_enable = await device.ble_setconfig(enable=True, enable_rpc=True)
     if not ble_enable["restart_required"]:
-        return False
+        return True
+    LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
+    await device.trigger_reboot(3500)
     return True

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -119,5 +119,5 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
     if not ble_enable["restart_required"]:
         return True
     LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
-    await device.trigger_reboot()
+    await device.trigger_reboot(3500)
     return True

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -107,7 +107,7 @@ def parse_ble_scan_result_event(
 async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
     """Ensure BLE is enabled.
 
-    Returns True if the device was restarted.
+    Returns True if the device needs to be restarted.
 
     Raises RpcCallError if BLE is not supported or could not
     be enabled.
@@ -117,7 +117,5 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
         return False
     ble_enable = await device.ble_setconfig(enable=True, enable_rpc=True)
     if not ble_enable["restart_required"]:
-        return True
-    LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
-    await device.trigger_reboot(3500)
+        return False
     return True

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -117,7 +117,7 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
         return False
     ble_enable = await device.ble_setconfig(enable=True, enable_rpc=True)
     if not ble_enable["restart_required"]:
-        return True
+        return False
     LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
     await device.trigger_reboot(3500)
     return True

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -1,6 +1,7 @@
 """Shelly Gen2 BLE support."""
 from __future__ import annotations
 
+import logging
 from base64 import b64decode
 from typing import Any
 
@@ -19,6 +20,8 @@ from .const import (
     VAR_VERSION,
     VAR_WINDOW_MS,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 async def _async_get_scripts_by_name(device: RpcDevice) -> dict[str, int]:
@@ -92,3 +95,22 @@ def parse_ble_scan_result_event(
             (b64decode(advertisement_data_b64), b64decode(scan_response_b64))
         ),
     )
+
+
+async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
+    """Ensure BLE is enabled.
+
+    Returns True if the device was restarted.
+
+    Raises RpcCallError if BLE is not supported or could not
+    be enabled.
+    """
+    ble_config = await device.ble_getconfig()
+    if ble_config["enable"]:
+        return False
+    ble_enable = await device.ble_setconfig(enable=True, enable_rpc=True)
+    if not ble_enable["restart_required"]:
+        return True
+    LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
+    await device.trigger_reboot()
+    return True

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -226,9 +226,9 @@ class RpcDevice:
         params = {"stage": "beta"} if beta else {"stage": "stable"}
         await self.call_rpc("Shelly.Update", params)
 
-    async def trigger_reboot(self) -> None:
+    async def trigger_reboot(self, delay_ms: int) -> None:
         """Trigger a device reboot."""
-        await self.call_rpc("Shelly.Reboot")
+        await self.call_rpc("Shelly.Reboot", {"delay_ms": delay_ms or 1000})
 
     async def update_status(self) -> None:
         """Get device status from 'Shelly.GetStatus'."""

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -40,6 +40,25 @@ class ShellyScriptCode(TypedDict, total=False):
     data: str
 
 
+class ShellyBLERpcConfig(TypedDict, total=False):
+    """Shelly BLE RPC Config."""
+
+    enable: bool
+
+
+class ShellyBLEConfig(TypedDict, total=False):
+    """Shelly BLE Config."""
+
+    enable: bool
+    rpc: ShellyBLERpcConfig
+
+
+class ShellyBLESetConfig(TypedDict, total=False):
+    """Shelly BLE Set Config."""
+
+    restart_required: bool
+
+
 def mergedicts(dict1: dict, dict2: dict) -> dict:
     """Deep dicts merge."""
     result = dict(dict1)
@@ -247,6 +266,19 @@ class RpcDevice:
     async def script_stop(self, script_id: int) -> None:
         """Stop a script using 'Script.Stop'."""
         await self.call_rpc("Script.Stop", {"id": script_id})
+
+    async def ble_setconfig(self, enable: bool, enable_rpc: bool) -> ShellyBLESetConfig:
+        """Enable or disable ble with BLE.SetConfig."""
+        return cast(
+            ShellyBLESetConfig,
+            await self.call_rpc(
+                "BLE.SetConfig", {"enable": enable, "rpc": {"enable": enable_rpc}}
+            ),
+        )
+
+    async def ble_getconfig(self) -> ShellyBLEConfig:
+        """Get the BLE config with BLE.GetConfig."""
+        return cast(ShellyBLEConfig, await self.call_rpc("BLE.GetConfig"))
 
     @property
     def requires_auth(self) -> bool:

--- a/aioshelly/rpc_device.py
+++ b/aioshelly/rpc_device.py
@@ -272,7 +272,8 @@ class RpcDevice:
         return cast(
             ShellyBLESetConfig,
             await self.call_rpc(
-                "BLE.SetConfig", {"enable": enable, "rpc": {"enable": enable_rpc}}
+                "BLE.SetConfig",
+                {"config": {"enable": enable, "rpc": {"enable": enable_rpc}}},
             ),
         )
 


### PR DESCRIPTION
If the shelly doesn't have BLE enabled and the user turns on the scanner it should just work instead of failing.

supports https://github.com/home-assistant/core/pull/82153
