### PR TITLE
Fix pre-commit flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings==1.5.0
+          - flake8-docstrings==1.6.0
         files: ^aioshelly/.+\.py$
         args:
           - --max-line-length=500


### PR DESCRIPTION
`pre-commit` used old `flake8` version from `gitlab` which is no longer available, updated to the latest one using the recommended repo from the docs:
https://flake8.pycqa.org/en/latest/user/using-hooks.html#usage-with-the-pre-commit-git-hooks-framework