### PR TITLE
Raise exception on disconnect for all inflight calls

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -252,7 +252,8 @@ class WsRPC:
         _LOGGER.debug("Websocket client connection from %s closed", self._ip_address)
 
         for call_item in self._calls.values():
-            call_item.resolve.cancel()
+            if not call_item.resolve.done():
+                call_item.resolve.set_exception(DeviceConnectionError(call_item))
         self._calls.clear()
 
         if not self._client.closed:


### PR DESCRIPTION
Calls were cancelled when the device disconnected which meant anything awaiting them would get CancelledError instead of raising an exception about being disconnected.

We now set the exception to DeviceConnectionError to avoid unexpected cancellation.

The UI in HA now gets `homeassistant.exceptions.HomeAssistantError: Call RPC for shellypluswdus-441793ccbdf4 light_0 connection error, method: Light.Set, params: {'id': 0, 'on': False}, error: DeviceConnectionError()` when the connection drops when trying to turn on/off a dimmer