### PR TITLE
Fix state updates never coming back after reconnect

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -159,14 +159,14 @@ class RpcDevice:
             # Auth error during async init, used by sleeping devices
             # Will raise 'invalidAuthError' on next property read
             if not async_init:
-                await self.shutdown()
+                await self._disconnect_websocket()
                 raise
             self.initialized = True
         except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
             if not async_init:
-                await self.shutdown()
+                await self._disconnect_websocket()
                 raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
@@ -175,9 +175,17 @@ class RpcDevice:
             self._update_listener(self, UpdateType.INITIALIZED)
 
     async def shutdown(self) -> None:
-        """Shutdown device."""
-        self._update_listener = None
+        """Shutdown device and remove the listener.
 
+        This method will unsubscribe the update listener and disconnect the websocket.
+
+        To fully reverse a shutdown, call initialize() and subscribe_updates() again.
+        """
+        self._update_listener = None
+        await self._disconnect_websocket()
+
+    async def _disconnect_websocket(self) -> None:
+        """Disconnect websocket."""
         if self._unsub_ws:
             self._unsub_ws()
             self._unsub_ws = None


### PR DESCRIPTION
If we hit a connection or invalid auth error we would clear the _update_listener because it called shutdown which cleared the listener and closed the websocket connection.

We now only shutdown the websocket connection so
updates keep working once we reconnect