### PR TITLE
Add python 3.11 to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py39, py310, lint, mypy
+envlist = py39, py310, py311, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
   3.9: py39, lint, mypy
   3.10: py310
+  3.11: py311
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Related to https://github.com/home-assistant-libs/aioshelly/pull/306
Add the 3.11 to local `tox` runs