### PR TITLE
Fix broken callback in example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -26,7 +26,7 @@ from aioshelly.exceptions import (
     ShellyError,
     WrongShellyGen,
 )
-from aioshelly.rpc_device import RpcDevice, WsServer
+from aioshelly.rpc_device import RpcDevice, WsServer, UpdateType
 
 coap_context = COAP()
 ws_context = WsServer()
@@ -134,7 +134,7 @@ async def connect_and_print_device(
     device.subscribe_updates(device_updated)
 
 
-def device_updated(cb_device: BlockDevice | RpcDevice) -> None:
+def device_updated(cb_device: BlockDevice | RpcDevice, *_: UpdateType) -> None:
     """Device updated callback."""
     print()
     print(f"{datetime.now().strftime('%H:%M:%S')} Device updated!")


### PR DESCRIPTION
example.py was broken for Gen2 devices in https://github.com/home-assistant-libs/aioshelly/pull/283/files

Callback function needs to accept 2 parameters for Gen 2 devices but 1 parameter for Gen 1 devices - there are a lot of ways to fix this, if you'd prefer to see something else (print status? keyword arg instead of *args?) I can change it.