### PR TITLE
Add support for specifying port in Gen2 devices

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -92,7 +92,7 @@ def create_scanner(
         name,
         HaBluetoothConnector(
             # no active connections to shelly yet
-            client=None,  # type: ignore[arg-type]
+            client=None,
             source=source,
             can_connect=lambda: False,
         ),
@@ -114,6 +114,6 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
     ble_enable = await device.ble_setconfig(enable=True, enable_rpc=True)
     if not ble_enable["restart_required"]:
         return False
-    LOGGER.info("BLE enabled, restarting device %s", device.ip_address)
+    LOGGER.info("BLE enabled, restarting device %s:%s", device.ip_address, device.port)
     await device.trigger_reboot(3500)
     return True

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -92,7 +92,7 @@ def create_scanner(
         name,
         HaBluetoothConnector(
             # no active connections to shelly yet
-            client=None,
+            client=None,  # type: ignore[arg-type]
             source=source,
             can_connect=lambda: False,
         ),

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -18,6 +18,7 @@ from yarl import URL
 from ..common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
 from ..const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT, HTTP_CALL_TIMEOUT, MODEL_RGBW2
 from ..exceptions import (
+    CustomPortNotSupported,
     DeviceConnectionError,
     FirmwareUnsupported,
     InvalidAuthError,
@@ -117,6 +118,10 @@ class BlockDevice:
         """Device initialization."""
         if self._initializing:
             raise RuntimeError("Already initializing")
+
+        # GEN1 cannot be configured behind a range extender as CoAP port cannot be natted
+        if self.options.port != 80:
+            raise CustomPortNotSupported
 
         self._initializing = True
         self.initialized = False

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -47,6 +47,10 @@ class MacAddressMismatchError(ShellyError):
     """Raised if input MAC address does not match the device MAC address."""
 
 
+class CustomPortNotSupported(ShellyError):
+    """Raise if GEN1 devices are access with custom port."""
+
+
 class RpcCallError(ShellyError):
     """Raised to indicate errors in RPC call."""
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -153,6 +153,7 @@ class RpcDevice:
         self._initializing = True
         self.initialized = False
         ip = self.options.ip_address
+        port = self.options.port
         try:
             self._shelly = await get_info(
                 self.aiohttp_session,
@@ -181,7 +182,7 @@ class RpcDevice:
             self.initialized = True
         except InvalidAuthError as err:
             self._last_error = InvalidAuthError(err)
-            _LOGGER.debug("host %s:%s: error: %r", ip, self.port, self._last_error)
+            _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)
             # Auth error during async init, used by sleeping devices
             # Will raise 'invalidAuthError' on next property read
             if not async_init:
@@ -190,13 +191,13 @@ class RpcDevice:
             self.initialized = True
         except (MacAddressMismatchError, FirmwareUnsupported) as err:
             self._last_error = err
-            _LOGGER.debug("host %s:%s: error: %r", ip, self.port, err)
+            _LOGGER.debug("host %s:%s: error: %r", ip, port, err)
             if not async_init:
                 await self._disconnect_websocket()
                 raise
         except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
-            _LOGGER.debug("host %s:%s: error: %r", ip, self.port, self._last_error)
+            _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)
             if not async_init:
                 await self._disconnect_websocket()
                 raise DeviceConnectionError(err) from err

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -28,7 +28,9 @@ async def create_device(
 ) -> Any:
     """Create a Gen1/Gen2/Gen3 device."""
     if gen is None:
-        if info := await get_info(aiohttp_session, options.ip_address):
+        if info := await get_info(
+            aiohttp_session, options.ip_address, port=options.port
+        ):
             gen = info.get("gen", 1)
         else:
             raise ShellyError("Unknown Gen")
@@ -70,14 +72,15 @@ def device_updated(
 
 def print_device(device: BlockDevice | RpcDevice) -> None:
     """Print device data."""
+    port = getattr(device, "port", 80)
     if not device.initialized:
         print()
-        print(f"** Device @ {device.ip_address} not initialized **")
+        print(f"** Device @ {device.ip_address}:{port} not initialized **")
         print()
         return
 
     model_name = MODEL_NAMES.get(device.model) or f"Unknown ({device.model})"
-    print(f"** {device.name} - {model_name}  @ {device.ip_address} **")
+    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port} **")
     print()
 
     if device.gen in BLOCK_GENERATIONS:

--- a/tools/example.py
+++ b/tools/example.py
@@ -26,6 +26,7 @@ from common import (
 from aioshelly.common import ConnectionOptions
 from aioshelly.const import WS_API_URL
 from aioshelly.exceptions import (
+    CustomPortNotSupported,
     DeviceConnectionError,
     FirmwareUnsupported,
     InvalidAuthError,
@@ -55,6 +56,9 @@ async def test_single(options: ConnectionOptions, init: bool, gen: int | None) -
             return
         except WrongShellyGen:
             print(f"Wrong Shelly generation {gen}, device gen: {2 if gen==1 else 1}")
+            return
+        except CustomPortNotSupported:
+            print(f"Custom port ({options.port}) not supported for Gen1")
             return
 
         print_device(device)

--- a/tools/example.py
+++ b/tools/example.py
@@ -46,7 +46,9 @@ async def test_single(options: ConnectionOptions, init: bool, gen: int | None) -
             print(f"Invalid or missing authorization, error: {repr(err)}")
             return
         except DeviceConnectionError as err:
-            print(f"Error connecting to {options.ip_address}, error: {repr(err)}")
+            print(
+                f"Error connecting to {options.ip_address}:{options.port}, error: {repr(err)}"
+            )
             return
         except MacAddressMismatchError as err:
             print(f"MAC address mismatch, error: {repr(err)}")
@@ -65,6 +67,8 @@ async def test_single(options: ConnectionOptions, init: bool, gen: int | None) -
 
 async def test_devices(init: bool, gen: int | None) -> None:
     """Test multiple devices."""
+    options: ConnectionOptions
+
     device_options = []
     with open("devices.json", encoding="utf8") as fp:
         for line in fp:
@@ -86,7 +90,7 @@ async def test_devices(init: bool, gen: int | None) -> None:
                 continue
 
             print()
-            print(f"Error printing device @ {options.ip_address}")
+            print(f"Error printing device @ {options.ip_address}:{options.port}")
 
             if isinstance(result, FirmwareUnsupported):
                 print("Device firmware not supported")
@@ -112,6 +116,13 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser = argparse.ArgumentParser(description="aioshelly example")
     parser.add_argument(
         "--ip_address", "-ip", type=str, help="Test single device by IP address"
+    )
+    parser.add_argument(
+        "--device_port",
+        "-dp",
+        type=int,
+        default=80,
+        help="Port to use when testing single device",
     )
     parser.add_argument(
         "--coap_port",
@@ -161,7 +172,6 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser.add_argument(
         "--mac", "-m", type=str, help="Optional device MAC to subscribe for updates"
     )
-
     parser.add_argument(
         "--update_ws",
         "-uw",
@@ -213,7 +223,11 @@ async def main() -> None:
         if args.username and args.password is None:
             parser.error("--username and --password must be used together")
         options = ConnectionOptions(
-            args.ip_address, args.username, args.password, device_mac=args.mac
+            args.ip_address,
+            args.username,
+            args.password,
+            device_mac=args.mac,
+            port=args.device_port,
         )
         if args.update_ws:
             await update_outbound_ws(options, args.init, args.update_ws)


### PR DESCRIPTION
(Will rebase when https://github.com/home-assistant-libs/aioshelly/pull/324 is merged)

Enables support for Range Extender connected Gen2 devices (following request to use port as a parameter in https://github.com/home-assistant-libs/aioshelly/pull/322).

Unfortunately, it looks like CoAP is not possible due to Range Extender only forwarding to port 80 on the device. If my understanding is incorrect I'd be happy to try and incorporate support for Gen1 devices as well.

If this PR is accepted, there will need to be additional work to the Home Assistant configuration flow to specify ports.