### PR TITLE
Add support for subscribing to updates by device MAC

### DIFF
--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import socket
 import struct
 from types import TracebackType
 from typing import Callable, cast
+
+from ..json import JSONDecodeError, json_loads
 
 COAP_OPTION_DEVICE_ID = 3332
 
@@ -65,8 +66,8 @@ class CoapMessage:
             raise InvalidMessage("Received message without data")
 
         try:
-            self.payload = json.loads(data.decode())
-        except (json.decoder.JSONDecodeError, UnicodeDecodeError) as err:
+            self.payload = json_loads(data.decode())
+        except (JSONDecodeError, UnicodeDecodeError) as err:
             raise InvalidMessage(
                 f"Message type {self.code} is not a valid JSON format: {str(payload)}"
             ) from err
@@ -166,7 +167,7 @@ class COAP(asyncio.DatagramProtocol):
             return
 
         try:
-            device_id = msg.options[COAP_OPTION_DEVICE_ID].decode().split("#")[1]
+            device_id = msg.options[COAP_OPTION_DEVICE_ID].decode().split("#")[1][-6:]
         except (UnicodeDecodeError, IndexError) as err:
             _LOGGER.debug("Invalid device id from host %s: %s", host_ip, err)
             return

--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -87,18 +87,18 @@ class CoapMessage:
     @staticmethod
     def _read_extended_field_value(value: int, raw_data: bytes) -> tuple[int, bytes]:
         """Decode large values of option delta and option length."""
-        if value >= 0 and value < 13:
+        if 0 <= value < 13:
             return (value, raw_data)
-        elif value == 13:
+        if value == 13:
             if len(raw_data) < 1:
                 raise InvalidMessage("Option ended prematurely")
             return (raw_data[0] + 13, raw_data[1:])
-        elif value == 14:
+        if value == 14:
             if len(raw_data) < 2:
                 raise InvalidMessage("Option ended prematurely")
             return (int.from_bytes(raw_data[:2], "big") + 269, raw_data[2:])
-        else:
-            raise InvalidMessage("Option contained partial payload marker.")
+
+        raise InvalidMessage("Option contained partial payload marker.")
 
 
 def socket_init(socket_port: int) -> socket.socket:

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -62,8 +62,11 @@ class BlockDevice:
         self._settings: dict[str, Any] | None = None
         self.shelly: dict[str, Any] | None = None
         self._status: dict[str, Any] | None = None
+        sub_id = options.ip_address
+        if options.device_mac:
+            sub_id = options.device_mac[-6:]
         self._unsub_coap: Callable | None = coap_context.subscribe_updates(
-            options.ip_address, self._coap_message_received
+            sub_id, self._coap_message_received
         )
         self._update_listener: Callable | None = None
         self._coap_response_events: dict = {}

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -20,6 +20,7 @@ from ..exceptions import (
     ShellyError,
     WrongShellyGen,
 )
+from ..json import json_loads
 from .coap import COAP, CoapMessage
 
 BLOCK_VALUE_UNIT = "U"
@@ -278,7 +279,7 @@ class BlockDevice:
             self._last_error = DeviceConnectionError(err)
             raise DeviceConnectionError from err
 
-        resp_json = await resp.json()
+        resp_json = await resp.json(loads=json_loads)
         _LOGGER.debug("aiohttp response: %s", resp_json)
         return cast(dict, resp_json)
 

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -33,6 +33,7 @@ class ConnectionOptions:
     password: str | None = None
     temperature_unit: str = "C"
     auth: aiohttp.BasicAuth | None = None
+    device_mac: str | None = None
 
     def __post_init__(self) -> None:
         """Call after initialization."""

--- a/aioshelly/json.py
+++ b/aioshelly/json.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import orjson
 
+JSONDecodeError = orjson.JSONDecodeError
 json_loads = orjson.loads  # pylint: disable=no-member
 
 

--- a/aioshelly/json.py
+++ b/aioshelly/json.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import orjson
 
-JSONDecodeError = orjson.JSONDecodeError
+JSONDecodeError = orjson.JSONDecodeError  # pylint: disable=no-member
 json_loads = orjson.loads  # pylint: disable=no-member
 
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -63,8 +63,11 @@ class RpcDevice:
         self._event: dict[str, Any] | None = None
         self._config: dict[str, Any] | None = None
         self._wsrpc = WsRPC(options.ip_address, self._on_notification)
+        sub_id = options.ip_address
+        if options.device_mac:
+            sub_id = options.device_mac
         self._unsub_ws: Callable | None = ws_context.subscribe_updates(
-            options.ip_address, self._wsrpc.handle_frame
+            sub_id, self._wsrpc.handle_frame
         )
         self._update_listener: Callable | None = None
         self.initialized: bool = False

--- a/example.py
+++ b/example.py
@@ -240,6 +240,9 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser.add_argument(
         "--debug", "-deb", action="store_true", help="Enable debug level for logging"
     )
+    parser.add_argument(
+        "--mac", "-m", type=str, help="Optional device MAC to subscribe for updates"
+    )
 
     arguments = parser.parse_args()
 
@@ -278,7 +281,9 @@ async def main() -> None:
     elif args.ip_address:
         if args.username and args.password is None:
             parser.error("--username and --password must be used together")
-        options = ConnectionOptions(args.ip_address, args.username, args.password)
+        options = ConnectionOptions(
+            args.ip_address, args.username, args.password, device_mac=args.mac
+        )
         await test_single(options, args.init, gen)
     else:
         parser.error("--ip_address or --devices must be specified")


### PR DESCRIPTION
Add options to subscribe for updates using device MAC (device ID)
Subscribing using device ID will help to support devices behind NAT, proxies, or if device IP changes
Implementation is backward compatible and allow subscribing for updates either by MAC or device IP, we can later drop the support for subscribing by IP.

Closes https://github.com/home-assistant-libs/aioshelly/issues/182

Gen1:
- CoAP contains the device ID in CoAP option 3332, for this parsing of options was added, logic for parsing options is based on https://github.com/chrysn/aiocoap/blob/master/aiocoap/options.py
- For compatibility with older Gen1 devices that only include the last 6 chars of MAC, comparison only compare the last 6 MAC chars

Gen2:
- Device ID is sent on every frame as `src`

Checked on multiple Gen1/Gen2 devices with various firmware versions for Gen1.
Update `example.py` to test subscribing by MAC, for testing with debug enabled:
```
python example.py --ip 192.168.1.75 -i -deb -m "ABCDEF123456"
```