### PR TITLE
Bump version to 5.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "5.2.1"
+VERSION = "5.3.0"
 
 
 setup(


### PR DESCRIPTION
Mainly to include https://github.com/home-assistant-libs/aioshelly/pull/332 since these devices start shipping and we don't have thier model names in `5.2.1`
