### PR TITLE
Fix ping task - don't ping if transport is closed

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -235,8 +235,14 @@ class WsRPC:
             # so schedule next heartbeat
             self._schedule_heartbeat()
             return
+        asyncio.create_task(self._ping_if_not_closed())
+
+    async def _ping_if_not_closed(self) -> None:
+        """Send ping if the client is not closed."""
+        if not self._client or self._client.closed:
+            return
         self._schedule_pong_response_cb()
-        asyncio.create_task(self._client.ping())
+        await self._client.ping()
 
     def _pong_not_received(self) -> None:
         """Pong not received."""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "5.3.0"
+VERSION = "5.3.1"
 
 
 setup(


### PR DESCRIPTION
Fix race when pinging on closed transport:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 676, in ping
    await self._send_frame(message, WSMsgType.PING)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 653, in _send_frame
    self._write(header + message)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 663, in _write
    raise ConnectionResetError("Cannot write to closing transport")
ConnectionResetError: Cannot write to closing transport
```