### PR TITLE
Add an extra line for Shelly Plus 2PM (new model name)

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -70,6 +70,7 @@ MODEL_NAMES = {
     "SNSW-001X16EU": "Shelly Plus 1",
     "SNSW-0024X": "Shelly Plus I4",
     "SNSW-002P16EU": "Shelly Plus 2PM",
+    "SNSW-102P16EU": "Shelly Plus 2PM",  # hw v2
     "SPEM-003CEBEU": "Shelly Pro 3EM",
     "SPSW-001PE16EU": "Shelly Pro 1PM",
     "SPSW-001XE16EU": "Shelly Pro 1",


### PR DESCRIPTION
My new Shelly Plus 2PM`s model name is not recognised.
I found that there exist an entry for my model, but with model name SNSW-002P16EU.
My new shelly device has the model name SNSW-102P16EU.

Below is some of the output from running example.py
```
** shelly_alias - Unknown (SNSW-102P16EU)  @ 192.168.1.10 **
```

I added a 2nd entry to const.py with the new model name and a trailing comment.