### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ["--py39-plus"]
+        args: ["--py310-plus"]
   - repo: https://github.com/ambv/black
     rev: 23.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Asynchronous library to control Shelly devices
 
 ## Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 - bluetooth-data-tools
 - aiohttp
 - orjson

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 show_error_codes = true
 follow_imports = silent
 ignore_missing_imports = true

--- a/pylintrc
+++ b/pylintrc
@@ -22,7 +22,6 @@ max-public-methods=25
 # wrong-import-order - isort guards this
 disable=
   format,
-  abstract-class-little-used,
   abstract-method,
   cyclic-import,
   duplicate-code,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     package_data={"aioshelly": ["py.typed"]},
     zip_safe=True,
     platforms="any",
@@ -29,8 +29,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py39, py310, py311, lint, mypy
+envlist = py310, py311, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.9: py39, lint, mypy
-  3.10: py310
+  3.10: py310, lint, mypy
   3.11: py311
 
 [testenv:lint]


### PR DESCRIPTION
# Drop Python 3.9 support

minor fix for pylintrc
```
pylintrc:1:0: R0022: Useless option value for '--disable', 'abstract-class-little-used' was removed from pylint, see https://pylint.pycqa.org/en/latest/whatsnew/1/1.4.html#what-s-new-in-pylint-1-4-3. (useless-option-value)
```