### PR TITLE
Abort if input MAC does not match the device MAC

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -18,6 +18,7 @@ from ..const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT, HTTP_CALL_TIMEOUT
 from ..exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
+    MacAddressMismatchError,
     NotInitialized,
     ShellyError,
     WrongShellyGen,
@@ -151,6 +152,12 @@ class BlockDevice:
             if not async_init:
                 self.shutdown()
                 raise self._last_error from err
+        except MacAddressMismatchError as err:
+            self._last_error = err
+            _LOGGER.debug("host %s: error: %r", ip, err)
+            if not async_init:
+                self.shutdown()
+                raise
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from enum import Enum, auto
 from http import HTTPStatus
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import aiohttp
 import async_timeout
@@ -117,7 +118,9 @@ class BlockDevice:
         self.initialized = False
         ip = self.options.ip_address
         try:
-            await self.update_shelly()
+            self._shelly = await get_info(
+                self.aiohttp_session, self.options.ip_address, self.options.device_mac
+            )
 
             if self.requires_auth and not self.options.auth:
                 raise InvalidAuthError("auth missing and required")
@@ -153,7 +156,7 @@ class BlockDevice:
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
             if not async_init:
                 self.shutdown()
-                raise DeviceConnectionError from err
+                raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
 

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -42,6 +42,10 @@ class InvalidAuthError(ShellyError):
     """Raised to indicate invalid or missing authentication error."""
 
 
+class MacAddressMismatchError(ShellyError):
+    """Raised if input MAC address does not match the device MAC address."""
+
+
 class RpcCallError(ShellyError):
     """Raised to indicate errors in RPC call."""
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from enum import Enum, auto
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import aiohttp
 import async_timeout
@@ -143,7 +144,9 @@ class RpcDevice:
         self.initialized = False
         ip = self.options.ip_address
         try:
-            self._shelly = await get_info(self.aiohttp_session, self.options.ip_address)
+            self._shelly = await get_info(
+                self.aiohttp_session, self.options.ip_address, self.options.device_mac
+            )
 
             if self.requires_auth:
                 if self.options.username is None or self.options.password is None:

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -16,6 +16,7 @@ from ..const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT, NOTIFY_WS_CLOSED
 from ..exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
+    MacAddressMismatchError,
     NotInitialized,
     RpcCallError,
     ShellyError,
@@ -175,6 +176,12 @@ class RpcDevice:
                 await self._disconnect_websocket()
                 raise
             self.initialized = True
+        except MacAddressMismatchError as err:
+            self._last_error = err
+            _LOGGER.debug("host %s: error: %r", ip, err)
+            if not async_init:
+                await self._disconnect_websocket()
+                raise
         except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)

--- a/example.py
+++ b/example.py
@@ -23,6 +23,7 @@ from aioshelly.exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
     InvalidAuthError,
+    MacAddressMismatchError,
     ShellyError,
     WrongShellyGen,
 )
@@ -68,6 +69,9 @@ async def test_single(options: ConnectionOptions, init: bool, gen: int | None) -
         except DeviceConnectionError as err:
             print(f"Error connecting to {options.ip_address}, error: {repr(err)}")
             return
+        except MacAddressMismatchError as err:
+            print(f"MAC address mismatch, error: {repr(err)}")
+            return
         except WrongShellyGen:
             print(f"Wrong Shelly generation {gen}, device gen: {2 if gen==1 else 1}")
             return
@@ -106,13 +110,15 @@ async def test_devices(init: bool, gen: int | None) -> None:
             print(f"Error printing device @ {options.ip_address}")
 
             if isinstance(result, FirmwareUnsupported):
-                print(f"Device firmware not supported")
+                print("Device firmware not supported")
             elif isinstance(result, InvalidAuthError):
-                print(f"Invalid or missing authorization")
+                print("Invalid or missing authorization")
             elif isinstance(result, DeviceConnectionError):
-                print(f"Error connecting to device")
+                print("Error connecting to device")
+            elif isinstance(result, MacAddressMismatchError):
+                print("MAC address mismatch error")
             elif isinstance(result, WrongShellyGen):
-                print(f"Wrong Shelly generation")
+                print("Wrong Shelly generation")
             else:
                 print()
                 traceback.print_tb(result.__traceback__)

--- a/pylintrc
+++ b/pylintrc
@@ -26,6 +26,7 @@ disable=
   cyclic-import,
   duplicate-code,
   inconsistent-return-statements,
+  too-many-branches,
   too-many-instance-attributes,
   too-many-public-methods,
   wrong-import-order,


### PR DESCRIPTION
Abort connection to device and raise `MacAddressMismatchError` if the supplied MAC address doesn't match the MAC address returned from the device in `/shelly`.

Since we supply the MAC address to allow routing incoming messages we can detect if the IP is wrong and we are connecting to another Shelly device.

I had few IPs mixed up after power failure 
1. Shelly IP mixed with a non Shelly device --> This is not harmful, Init will fail until HA detect the new IP from the device (DHCP/mDNS).
2. Shelly Gen1 IP mixed with Shelly Gen2 IP --> This will raise `WrongShellyGen` which is not handled by HA since it shouldn't happen (runtime error).
3. Shelly IP Mixed with another Shelly from the same Gen --> This creates a bad situation since init succeeds and entities from the one Shelly are added to the other Shelly and HA controls the wrong device.

By aborting we allow the init to fail until we get a new IP by DHCP or mDNS.

To test with wrong MAC:
```
python example.py --ip 192.168.1.49 --mac 1234A2E0BBA5 -i
MAC address mismatch, error: MacAddressMismatchError('Input MAC: 1234A2E0BBA5, Shelly MAC: 1234A2E0BBA6')
```

