### PR TITLE
Create futures with loop.create_future()

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -113,7 +113,7 @@ class RPCCall:
 
     __slots__ = ("auth", "call_id", "params", "method", "src", "dst", "resolve")
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         call_id: int,
         method: str,

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -407,8 +407,8 @@ class WsRPC:
                 resp = await future
         except asyncio.TimeoutError as exc:
             with contextlib.suppress(asyncio.CancelledError):
-                call.resolve.cancel()
-                await call.resolve
+                future.cancel()
+                await future
             raise DeviceConnectionError(call) from exc
 
         _LOGGER.debug("%s(%s) -> %s", call.method, call.params, resp)


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-future.html#asyncio.Future

> The rule of thumb is to never expose Future objects in user-facing APIs, and the recommended way to create a Future object is to call loop.create_future(). This way alternative event loop implementations can inject their own optimized implementations of a Future object.