### PR TITLE
Add support for devices with multiple profiles

### DIFF
--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -46,6 +46,10 @@ class MacAddressMismatchError(ShellyError):
     """Raised if input MAC address does not match the device MAC address."""
 
 
+class NotSupported(ShellyError):
+    """Raised if functionality not supported by device."""
+
+
 class RpcCallError(ShellyError):
     """Raised to indicate errors in RPC call."""
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -389,7 +389,7 @@ class RpcDevice:
         return self._config
 
     @property
-    def profiles(self) -> dict[str, Any] | None:
+    def profiles(self) -> dict[str, Any]:
         """Get device config."""
         if not self.initialized:
             raise NotInitialized


### PR DESCRIPTION
For example ShellyPlus 2PM can be configured as switch with 2 relays or a cover.

`curl http://192.168.1.133/rpc/Shelly.ListProfiles`

```json
{
  "profiles": {
    "cover": {
      "components": [
        {
          "type": "input",
          "count": 2
        },
        {
          "type": "cover",
          "count": 1
        }
      ]
    },
    "switch": {
      "components": [
        {
          "type": "input",
          "count": 2
        },
        {
          "type": "switch",
          "count": 2
        }
      ]
    }
  }
}
```

