### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4.1.1
         with:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py310, py311, lint, mypy
+envlist = py310, py311, py312, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
   3.10: py310, lint, mypy
   3.11: py311
+  3.12: py312
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
I did some tests with Python 3.12 and aiohttp 3.9.0 and everything looks fine.