### PR TITLE
Handle NotifyStatus frames with id

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -284,6 +284,7 @@ class WsRPC:
 
     def handle_frame(self, frame: dict[str, Any]) -> None:
         """Handle RPC frame."""
+        _LOGGER.debug("RPC frame: %s", frame)
         if peer_src := frame.get("src"):
             if self._session.dst is not None and peer_src != self._session.dst:
                 _LOGGER.warning(
@@ -296,7 +297,7 @@ class WsRPC:
         if method := frame.get("method"):
             # peer is invoking a method
             params = frame.get("params")
-            if frame_id:
+            if frame_id and method != "NotifyStatus":
                 # and expects a response
                 _LOGGER.debug("handle call for frame_id: %s", frame_id)
                 self._create_and_track_task(self._handle_call(frame_id))


### PR DESCRIPTION
Shelly Wall Display has an **`id`** on the NotifyStatus frame:

```
{'id': 0, 'src': 'ShellyWallDisplay-00082216C97B', 'dst': 'user_1', 'method': 'NotifyStatus', 'params': {'ts': 1701283262, 'thermostat:0': {'id': 0, 'enable': False, 'target_C': 21, 'current_C': 24.6, 'output': False, 'schedules': {'enable': False}}}}
```

```
{'id': 1701197400, 'src': 'ShellyWallDisplay-00082216C97B', 'dst': 'user_1', 'method': 'NotifyStatus', 'params': {'temperature:0': {'id': 0, 'tC': 22.8, 'tF': 73.1}, 'humidity:0': {'id': 0, 'rh': 43}, 'illuminance:0': {'id': 0, 'lux': 5, 'illumination': 'dark'}, 'ts': 1701197400}}
```

This break our logic.

This PR fix it in a general way.

