### PR TITLE
Bump Gen2 minimum firmware version to 1.0.0 (2023-08-03)

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -195,8 +195,8 @@ HTTP_CALL_TIMEOUT = 10
 # Firmware 1.8.0 release date (CoAP v2)
 GEN1_MIN_FIRMWARE_DATE = 20200812
 
-# Firmware 0.8.1 release date
-GEN2_MIN_FIRMWARE_DATE = 20210921
+# Firmware 1.0.0 release date
+GEN2_MIN_FIRMWARE_DATE = 20230803
 
 WS_HEARTBEAT = 55
 


### PR DESCRIPTION
Firmware 1.0.0 for gen2 devices is a completely new line of software that fixes many problems and introduces many new functionalities. Gen3 devices also use this line of software.

Changelog: https://shelly-api-docs.shelly.cloud/gen2/changelog#100-2023-08-03

Firmware 1.0.0 functionalities related to HA integration:
- Network frequency in status of EM, Switch, Cover components
- New settings for switches - "External consumption type"
- Sys Drop wakeup_period attribute from configuration (deprecated since 0.11.0)
We will be able to remove this method https://github.com/home-assistant/core/blob/c8bb72935d935680ea7a9c5f8bde552f2d8f7dcd/homeassistant/components/shelly/utils.py#L279-L281
