### PR TITLE
Bump Gen1 minimum firmware version to 1.11.0 (2021-07-15)

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -192,8 +192,8 @@ DEVICE_IO_TIMEOUT = 10
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10
 
-# Firmware 1.8.0 release date (CoAP v2)
-GEN1_MIN_FIRMWARE_DATE = 20200812
+# Firmware 1.13.0 release date (this also means 2.1.9 for Motion/Motion 2/TRV)
+GEN1_MIN_FIRMWARE_DATE = 20230503
 
 # Firmware 0.8.1 release date
 GEN2_MIN_FIRMWARE_DATE = 20210921

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -192,8 +192,8 @@ DEVICE_IO_TIMEOUT = 10
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10
 
-# Firmware 1.13.0 release date (this also means 2.1.9 for Motion/Motion 2/TRV)
-GEN1_MIN_FIRMWARE_DATE = 20230503
+# Firmware 1.11.0 release date
+GEN1_MIN_FIRMWARE_DATE = 20210715
 
 # Firmware 0.8.1 release date
 GEN2_MIN_FIRMWARE_DATE = 20210921


### PR DESCRIPTION
Due to many fixes and new functionalities introduced in subsequent firmware versions, the minimum firmware version supported by `aioshelly` is increased to 1.11.0 (2021-07-15). This release included the last major change in API functionality (`transition` for lights).

Changelog: https://shelly-api-docs.shelly.cloud/gen1/#changelog