### PR TITLE
Change the minimum supported gen1 firmware to 1.9.0

### DIFF
--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -15,7 +15,9 @@ from yarl import URL
 from .const import (
     CONNECT_ERRORS,
     DEVICE_IO_TIMEOUT,
+    GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE,
     GEN1_MIN_FIRMWARE_DATE,
+    GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION,
     GEN2_MIN_FIRMWARE_DATE,
     GEN3_MIN_FIRMWARE_DATE,
 )
@@ -117,7 +119,10 @@ def shelly_supported_firmware(result: dict[str, Any]) -> bool:
         ]:
             return False
         fw_str = result["fw"]
-        fw_ver = GEN1_MIN_FIRMWARE_DATE
+        if result["type"] in GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION:
+            fw_ver = GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE
+        else:
+            fw_ver = GEN1_MIN_FIRMWARE_DATE
     else:
         fw_str = result["fw_id"]
         fw_ver = (

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -212,8 +212,8 @@ DEVICE_IO_TIMEOUT = 10
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10
 
-# Firmware 1.9.4 release date (latest firmware for SHPLG-1)
-GEN1_MIN_FIRMWARE_DATE = 20210115
+# Firmware 1.9.0 release date
+GEN1_MIN_FIRMWARE_DATE = 20201124
 
 # Firmware 1.11.0 release date (introduction of light transition)
 GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE = 20210715

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -203,8 +203,8 @@ DEVICE_IO_TIMEOUT = 10
 # Timeout used for HTTP calls
 HTTP_CALL_TIMEOUT = 10
 
-# Firmware 1.11.0 release date
-GEN1_MIN_FIRMWARE_DATE = 20210715
+# Firmware 1.9.4 release date (latest firmware for SHPLG-1)
+GEN1_MIN_FIRMWARE_DATE = 20210115
 
 # Firmware 1.0.0 release date
 GEN2_MIN_FIRMWARE_DATE = 20230803

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -197,6 +197,15 @@ MODEL_NAMES = {
     MODEL_PLUS_PM_MINI_G3: "Shelly Plus PM Mini",
 }
 
+GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION = (
+    MODEL_DUO,
+    MODEL_BULB_RGBW,
+    MODEL_DIMMER,
+    MODEL_DIMMER_2,
+    MODEL_RGBW2,
+    MODEL_VINTAGE_V2,
+)
+
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10
 
@@ -205,6 +214,9 @@ HTTP_CALL_TIMEOUT = 10
 
 # Firmware 1.9.4 release date (latest firmware for SHPLG-1)
 GEN1_MIN_FIRMWARE_DATE = 20210115
+
+# Firmware 1.11.0 release date (introduction of light transition)
+GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE = 20210715
 
 # Firmware 1.0.0 release date
 GEN2_MIN_FIRMWARE_DATE = 20230803

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -216,7 +216,8 @@ HTTP_CALL_TIMEOUT = 10
 GEN1_MIN_FIRMWARE_DATE = 20201124
 
 # Firmware 1.11.0 release date (introduction of light transition)
-GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE = 20210715
+# Due to date fluctuation for different models, 20210710 was used.
+GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE = 20210710
 
 # Firmware 1.0.0 release date
 GEN2_MIN_FIRMWARE_DATE = 20230803


### PR DESCRIPTION
The last firmware for SHPLG-1 is 1.9.4, and some SHUNI-1 are stuck with firmware `20210105-095645/release-1.9@8517d431+`, so I suggest using 1.9.0 as a minimum, except for bulbs that support light transition, in case these bulbs, the minimum firmware remains at version 1.11.0.

Related to: https://github.com/home-assistant/core/issues/107352