### PR TITLE
Get firmware info from Shelly update server

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -358,7 +358,7 @@ class BlockDevice:
 
     async def get_latest_firmware(self) -> None | str:
         """Get the latest available firmware information from Shelly."""
-        if self._latest_firmware == {}:
+        if not self._latest_firmware:
             _LOGGER.debug("Getting latest firmware information from Shelly Cloud")
             url = URL.build(
                 scheme="http", host="api.shelly.cloud", path="/files/firmware"

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -358,7 +358,7 @@ class BlockDevice:
 
     async def get_latest_firmware(self) -> None | str:
         """Get the latest available firmware information from Shelly."""
-        if self._latest_firmware is {}:
+        if self._latest_firmware == {}:
             _LOGGER.debug("Getting latest firmware information from Shelly Cloud")
             url = URL.build(
                 scheme="http", host="api.shelly.cloud", path="/files/firmware"

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -322,7 +322,7 @@ class RpcDevice:
     async def get_latest_firmware(self) -> None | str:
         """Get the latest available firmware information from Shelly."""
         model = self.shelly["app"]
-        if self._latest_firmware == {} or not self._latest_firmware.get(model):
+        if not self._latest_firmware or not self._latest_firmware.get(model):
             _LOGGER.debug("Getting latest firmware information from Shelly Cloud")
             url = URL.build(
                 scheme="https",

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -322,7 +322,7 @@ class RpcDevice:
     async def get_latest_firmware(self) -> None | str:
         """Get the latest available firmware information from Shelly."""
         model = self.shelly["app"]
-        if self._latest_firmware is {} or not self._latest_firmware.get(model):
+        if self._latest_firmware == {} or not self._latest_firmware.get(model):
             _LOGGER.debug("Getting latest firmware information from Shelly Cloud")
             url = URL.build(
                 scheme="https",


### PR DESCRIPTION
Retrieve the firmware version ( es. "20231219-133948/1.1.0-g34b5d4f") from the official URLs verified with Shelly.

This info will be used only to inform the users that a new version is available.
Code doesn't retrieve any URL so no action can be performed on the device.
