### PR TITLE
Trigger OTA for not initialized devices

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -14,7 +14,13 @@ from aiohttp import ClientResponseError
 from aiohttp.client import ClientResponse
 from yarl import URL
 
-from ..common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
+from ..common import (
+    ConnectionOptions,
+    IpOrOptionsType,
+    get_info,
+    process_ip_or_options,
+    trigger_ota_http,
+)
 from ..const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT, HTTP_CALL_TIMEOUT
 from ..exceptions import (
     DeviceConnectionError,
@@ -312,18 +318,17 @@ class BlockDevice:
         """Change device mode color/white."""
         return await self.http_request("get", "settings", {"mode": mode})
 
-    async def trigger_ota_update(
-        self, beta: bool = False, url: str | None = None
-    ) -> dict[str, Any]:
+    async def trigger_ota_update(self, beta: bool = False) -> bool:
         """Trigger an ota update."""
-        params = {"update": "true"}
-
-        if url:
-            params = {"url": url}
-        elif beta:
-            params = {"beta": "true"}
-
-        return await self.http_request("get", "ota", params=params)
+        return await trigger_ota_http(
+            self.aiohttp_session,
+            self.hostname,
+            self.gen,
+            self.options.username,
+            self.options.password,
+            None,
+            beta,
+        )
 
     async def trigger_reboot(self) -> None:
         """Trigger a device reboot."""

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -153,6 +153,7 @@ async def trigger_ota_http(
     beta: bool = False,
 ) -> bool:
     """Trigger a firmware update via OTA http endpoint."""
+    auth: aiohttp.BasicAuth | dict[str, Any] | None = None
     if gen in BLOCK_GENERATIONS:
         path = "/ota"
         auth = aiohttp.BasicAuth(username, password) if username and password else None

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -141,7 +141,12 @@ def shelly_supported_firmware(result: dict[str, Any]) -> bool:
     return int(match[0]) >= fw_ver
 
 
-async def trigger_ota_http(session: aiohttp.ClientSession, host: str, gen: int) -> bool:
+async def trigger_ota_http(
+    session: aiohttp.ClientSession,
+    host: str,
+    gen: int,
+    auth: aiohttp.BasicAuth | None = None,
+) -> bool:
     """Trigger a firmware update via OTA http endpoint."""
     if gen in BLOCK_GENERATIONS:
         path = "ota"
@@ -150,6 +155,7 @@ async def trigger_ota_http(session: aiohttp.ClientSession, host: str, gen: int) 
     try:
         await session.get(
             URL.build(scheme="http", host=host, path=f"/{path}"),
+            auth=auth,
             timeout=HTTP_CALL_TIMEOUT,
         )
     except aiohttp.ClientResponseError:

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -27,6 +27,7 @@ from .exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
     MacAddressMismatchError,
+    UnableToUpdateFirmware,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,19 +150,19 @@ async def trigger_ota_http(
 ) -> bool:
     """Trigger a firmware update via OTA http endpoint."""
     if gen in BLOCK_GENERATIONS:
-        path = "ota"
+        path = "/ota"
     else:
-        path = "rpc/Shelly.Update"
+        path = "/rpc/Shelly.Update"
     try:
         await session.get(
-            URL.build(scheme="http", host=host, path=f"/{path}"),
+            URL.build(scheme="http", host=host, path=path),
             auth=auth,
             timeout=HTTP_CALL_TIMEOUT,
         )
-    except aiohttp.ClientResponseError:
-        return False
-    except CONNECT_ERRORS:
-        return False
+    except aiohttp.ClientResponseError as exc:
+        raise UnableToUpdateFirmware from exc
+    except CONNECT_ERRORS as exc:
+        raise UnableToUpdateFirmware from exc
 
     _LOGGER.debug("Update in progress for device %s", host)
     return True

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -143,7 +143,7 @@ def shelly_supported_firmware(result: dict[str, Any]) -> bool:
     return int(match[0]) >= fw_ver
 
 
-async def trigger_ota_http(
+async def trigger_ota_http(  # pylint: disable=too-many-arguments
     session: aiohttp.ClientSession,
     host: str,
     gen: int,

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -46,6 +46,10 @@ class MacAddressMismatchError(ShellyError):
     """Raised if input MAC address does not match the device MAC address."""
 
 
+class UnableToUpdateFirmware(ShellyError):
+    """Raised if OTA is not able to complete the job."""
+
+
 class RpcCallError(ShellyError):
     """Raised to indicate errors in RPC call."""
 

--- a/aioshelly/rpc_device/authentication.py
+++ b/aioshelly/rpc_device/authentication.py
@@ -1,0 +1,65 @@
+"""Authentication code for Shelly RPC devices."""
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+def hex_hash(message: str) -> str:
+    """Get hex representation of sha256 hash of string."""
+    return hashlib.sha256(message.encode("utf-8")).hexdigest()
+
+
+HA2 = hex_hash("dummy_method:dummy_uri")
+
+
+@dataclass
+class AuthData:
+    """RPC Auth data class."""
+
+    realm: str
+    username: str
+    password: str
+
+    def __post_init__(self) -> None:
+        """Call after initialization."""
+        self.ha1 = hex_hash(f"{self.username}:{self.realm}:{self.password}")
+
+    def get_auth(self, nonce: int | None = None, n_c: int = 1) -> dict[str, Any]:
+        """Get auth for RPC calls."""
+        cnonce = int(time.time())
+        if nonce is None:
+            nonce = cnonce - 1800
+
+        # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
+        hashed = hex_hash(f"{self.ha1}:{nonce}:{n_c}:{cnonce}:auth:{HA2}")
+
+        return {
+            "realm": self.realm,
+            "username": self.username,
+            "nonce": nonce,
+            "cnonce": cnonce,
+            "response": hashed,
+            "algorithm": "SHA-256",
+        }
+
+
+# def get_gen2_auth(
+#     auth: AuthData, nonce: int | None = None, n_c: int = 1
+# ) -> dict[str, Any]:
+#     """Get auth for RPC calls."""
+#     cnonce = int(time.time())
+#     if nonce is None:
+#         nonce = cnonce - 1800
+
+#     # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
+#     hashed = hex_hash(f"{auth.ha1}:{nonce}:{n_c}:{cnonce}:auth:{HA2}")
+
+#     return {
+#         "realm": auth.realm,
+#         "username": auth.username,
+#         "nonce": nonce,
+#         "cnonce": cnonce,
+#         "response": hashed,
+#         "algorithm": "SHA-256",
+#     }

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -11,7 +11,13 @@ import aiohttp
 import async_timeout
 from aiohttp.client import ClientSession
 
-from ..common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
+from ..common import (
+    ConnectionOptions,
+    IpOrOptionsType,
+    get_info,
+    process_ip_or_options,
+    trigger_ota_http,
+)
 from ..const import CONNECT_ERRORS, DEVICE_IO_TIMEOUT, NOTIFY_WS_CLOSED
 from ..exceptions import (
     DeviceConnectionError,
@@ -217,10 +223,17 @@ class RpcDevice:
         """Subscribe to device status updates."""
         self._update_listener = update_listener
 
-    async def trigger_ota_update(self, beta: bool = False) -> None:
+    async def trigger_ota_update(self, beta: bool = False) -> bool:
         """Trigger an ota update."""
-        params = {"stage": "beta"} if beta else {"stage": "stable"}
-        await self.call_rpc("Shelly.Update", params)
+        return await trigger_ota_http(
+            self.aiohttp_session,
+            self.hostname,
+            self.gen,
+            self.options.username,
+            self.options.password,
+            self.shelly["auth_domain"],
+            beta,
+        )
 
     async def trigger_reboot(self, delay_ms: int = 1000) -> None:
         """Trigger a device reboot."""

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import socket
 import time
@@ -34,6 +33,7 @@ from ..exceptions import (
     RpcCallError,
 )
 from ..json import json_dumps, json_loads
+from .authentication import AuthData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,45 +59,6 @@ def _receive_json_or_raise(msg: WSMessage) -> dict[str, Any]:
         raise InvalidMessage(f"Received invalid JSON: {msg.data}") from err
 
     return data
-
-
-def hex_hash(message: str) -> str:
-    """Get hex representation of sha256 hash of string."""
-    return hashlib.sha256(message.encode("utf-8")).hexdigest()
-
-
-HA2 = hex_hash("dummy_method:dummy_uri")
-
-
-@dataclass
-class AuthData:
-    """RPC Auth data class."""
-
-    realm: str
-    username: str
-    password: str
-
-    def __post_init__(self) -> None:
-        """Call after initialization."""
-        self.ha1 = hex_hash(f"{self.username}:{self.realm}:{self.password}")
-
-    def get_auth(self, nonce: int | None = None, n_c: int = 1) -> dict[str, Any]:
-        """Get auth for RPC calls."""
-        cnonce = int(time.time())
-        if nonce is None:
-            nonce = cnonce - 1800
-
-        # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
-        hashed = hex_hash(f"{self.ha1}:{nonce}:{n_c}:{cnonce}:auth:{HA2}")
-
-        return {
-            "realm": self.realm,
-            "username": self.username,
-            "nonce": nonce,
-            "cnonce": cnonce,
-            "response": hashed,
-            "algorithm": "SHA-256",
-        }
 
 
 @dataclass


### PR DESCRIPTION
Allow OTA to work for devices that are not initialized.
This will be used in HA for repairing an unsupported firmware for connected devices.
