### PR TITLE
Add pylint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,3 +84,15 @@ repos:
     hooks:
       - id: mypy
         files: ^aioshelly/.+\.py$
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args:
+          [
+            "-rn",   # Only display messages
+            "-sn",   # Don't display the score
+          ]


### PR DESCRIPTION
CI runs `pylint`, but we don't locally.
This PR address this deficiency
