### PR TITLE
Add retry to Block HTTP requests

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -278,17 +278,18 @@ class BlockDevice:
         return event
 
     async def http_request(
-        self, method: str, path: str, params: Any | None = None
+        self, method: str, path: str, params: Any | None = None, retry: bool = True
     ) -> dict[str, Any]:
         """Device HTTP request."""
         if self.options.auth is None and self.requires_auth:
             raise InvalidAuthError("auth missing and required")
 
-        _LOGGER.debug("aiohttp request: /%s (params=%s)", path, params)
+        host = self.options.ip_address
+        _LOGGER.debug("host %s: http request: /%s (params=%s)", host, path, params)
         try:
             resp: ClientResponse = await self.aiohttp_session.request(
                 method,
-                URL.build(scheme="http", host=self.options.ip_address, path=f"/{path}"),
+                URL.build(scheme="http", host=host, path=f"/{path}"),
                 params=params,
                 auth=self.options.auth,
                 raise_for_status=True,
@@ -303,6 +304,13 @@ class BlockDevice:
             raise DeviceConnectionError from err
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
+            if retry:
+                _LOGGER.debug("host %s: http request error: %r", host, self._last_error)
+                return await self.http_request(method, path, params, retry=False)
+
+            _LOGGER.debug(
+                "host %s: http request retry error: %r", host, self._last_error
+            )
             raise DeviceConnectionError from err
 
         resp_json = await resp.json(loads=json_loads)


### PR DESCRIPTION
Since last week I have some failures with Gen1 devices, I still don't know if this is related to the transition to Python 3.12, a problem in my network or device problem. I suspect something happens faster and devices with ECO mode enabled fail to respond.

However even if it is a network or device problem, adding a single retry can improve the situation. We had many users complaining about failed actions, mainly to sleepy devices such as Shelly TRV & Shelly Motion.

I didn't increase the timeout, the retry still happen within our current timeout (10 seconds). For the last few days I had 33 retry occurrences and they all succeeded (meaning a single retry was enough, and without it 33 actions would fail). 
Retry will cause a short delay in action (up to two seconds) but is still acceptable from user experience and is better than a  failure.

