### PR TITLE
Allow setting of CoAP listening IP address

### DIFF
--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -115,8 +115,8 @@ class CoapMessage:
 
 
 def socket_init(
-    socket_ips: list[IPv4Address] | None = None,
     socket_port: int = DEFAULT_COAP_PORT,
+    socket_ips: list[IPv4Address] | None = None,
 ) -> socket.socket:
     """Init UDP socket to send/receive data with Shelly devices."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
@@ -168,7 +168,7 @@ class COAP(asyncio.DatagramProtocol):
     ) -> None:
         """Initialize the COAP manager."""
         loop = asyncio.get_running_loop()
-        self.sock = socket_init(socket_ips, socket_port)
+        self.sock = socket_init(socket_port, socket_ips)
         await loop.create_datagram_endpoint(lambda: self, sock=self.sock)
 
     async def request(self, ip: str, path: str) -> None:

--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -123,14 +123,11 @@ def socket_init(
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", socket_port))
     if socket_ips:
+        mreq = socket.inet_aton("224.0.1.187")
         for address in socket_ips:
             _LOGGER.debug("Socket initialized on %s:%s", address, socket_port)
-            mreq = struct.pack(
-                "=4sl",
-                socket.inet_aton("224.0.1.187"),
-                socket.inet_aton(address.exploded),
-            )
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+            mreq += socket.inet_aton(address.exploded)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
     else:
         _LOGGER.debug("Socket initialized on port %s (default interface)", socket_port)
         # INADDR_ANY indicates that the OS will chose an interface to join the given multicast group.

--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -123,10 +123,10 @@ def socket_init(
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", socket_port))
     if socket_ips:
-        mreq = socket.inet_aton("224.0.1.187")
         for address in socket_ips:
-            _LOGGER.debug("Socket initialized on %s:%s", address, socket_port)
-            mreq += socket.inet_aton(address.exploded)
+            ip = address.exploded
+            _LOGGER.debug("Socket initialized on %s:%s", ip, socket_port)
+            mreq = socket.inet_aton("224.0.1.187") + socket.inet_aton(ip)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
     else:
         _LOGGER.debug("Socket initialized on port %s (default interface)", socket_port)

--- a/aioshelly/block_device/coap.py
+++ b/aioshelly/block_device/coap.py
@@ -122,7 +122,7 @@ def socket_init(
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", socket_port))
-    _LOGGER.debug("Socket initialized on %s:%s", socket_ip, socket_port)
+    _LOGGER.debug("Socket initialized on port %s", socket_port)
     if socket_ip:
         for ip in socket_ip:
             mreq = struct.pack("=4sl", socket.inet_aton("224.0.1.187"), ip)

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -237,7 +237,6 @@ WS_HEARTBEAT = 55
 
 # Default network settings for gen1 devices ( CoAP )
 DEFAULT_COAP_PORT = 5683
-DEFAULT_IP_ADDRESS = "0.0.0.0"
 
 # Default Gen2 outbound websocket API URL
 WS_API_URL = "/api/shelly/ws"

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -235,6 +235,10 @@ GEN3_MIN_FIRMWARE_DATE = 20231102
 
 WS_HEARTBEAT = 55
 
+# Default network settings for gen1 devices ( CoAP )
+DEFAULT_COAP_PORT = 5683
+DEFAULT_IP_ADDRESS = "0.0.0.0"
+
 # Default Gen2 outbound websocket API URL
 WS_API_URL = "/api/shelly/ws"
 


### PR DESCRIPTION
Home Assistant allows users to specify the internal network they want to use.
This makes integrations listen on that specific adapter instead of 0.0.0.0.

This PR allows to specify a IP address for CoAP listening, while not chancing current behaviour.

Fixes #149 
