### PR TITLE
Simplify logging during debugging

### DIFF
--- a/tools/example.py
+++ b/tools/example.py
@@ -199,7 +199,11 @@ async def main() -> None:
         gen = 3
 
     if args.debug:
-        logging.basicConfig(level="DEBUG", force=True)
+        logging.basicConfig(level=logging.DEBUG)
+        if args.gen1:
+            logging.getLogger("aioshelly.rpc_device").setLevel(logging.INFO)
+        else:
+            logging.getLogger("aioshelly.block_device").setLevel(logging.INFO)
 
     def handle_sigint(_exit_code: int, _frame: FrameType) -> None:
         """Handle Keyboard signal interrupt (ctrl-c)."""

--- a/tools/example.py
+++ b/tools/example.py
@@ -200,6 +200,7 @@ async def main() -> None:
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
+        # if gen is in args reduce logging for other gens
         if args.gen1:
             logging.getLogger("aioshelly.rpc_device").setLevel(logging.INFO)
         else:

--- a/tools/example.py
+++ b/tools/example.py
@@ -203,7 +203,7 @@ async def main() -> None:
         # if gen is in args reduce logging for other gens
         if args.gen1:
             logging.getLogger("aioshelly.rpc_device").setLevel(logging.INFO)
-        else:
+        elif args.gen2 or args.gen3:
             logging.getLogger("aioshelly.block_device").setLevel(logging.INFO)
 
     def handle_sigint(_exit_code: int, _frame: FrameType) -> None:


### PR DESCRIPTION
Remove background noise from logging when debug option is enabled.

**Background**:

When you are debugging gen2, having all debug traffic from gen1 is just filling quickly the window making easy to miss what you need.
And the other way around with gen2.

**Solution**:

So if you specify a gen as arg, and only on that case, you just lower the logging for others gen in order to focus on what you are looking for