### PR TITLE
Use `uv` with `tox`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install uv tox tox-gh-actions tox-uv
       - name: Test with tox
         run: tox


### PR DESCRIPTION
I suggest replacing `pip` with `uv` for `tox`, which speeds up the process of testing commits.

When `pip` is used to install requirements for `tox`, we need about 50 seconds

![obraz](https://github.com/home-assistant-libs/aioshelly/assets/478555/7e825a5c-fd17-4d5a-9fb3-fc498af0d70c)


If we switch to `uv`, we only need 20 seconds

![obraz](https://github.com/home-assistant-libs/aioshelly/assets/478555/5064655d-6896-48d6-9e6b-163c678df536)
