### PR TITLE
Move call to initialize to user code

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -115,11 +115,6 @@ class BlockDevice:
         """Device ip address."""
         return self.options.ip_address
 
-    @property
-    def port(self) -> int:
-        """Device port."""
-        return DEFAULT_HTTP_PORT
-
     async def initialize(self) -> None:
         """Device initialization."""
         if self._initializing:

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -171,6 +171,7 @@ class BlockDevice:
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
+            self.shutdown()
             raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -171,7 +171,7 @@ class BlockDevice:
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            raise
+            raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from enum import Enum, auto
@@ -91,16 +92,10 @@ class RpcDevice:
         aiohttp_session: ClientSession,
         ws_context: WsServer,
         ip_or_options: IpOrOptionsType,
-        initialize: bool = True,
     ) -> RpcDevice:
         """Device creation."""
         options = await process_ip_or_options(ip_or_options)
-        instance = cls(ws_context, aiohttp_session, options)
-
-        if initialize:
-            await instance.initialize()
-
-        return instance
+        return cls(ws_context, aiohttp_session, options)
 
     def _on_notification(
         self, method: str, params: dict[str, Any] | None = None

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -14,12 +14,7 @@ from aiohttp import ClientSession
 
 from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions, get_info
-from aioshelly.const import (
-    BLOCK_GENERATIONS,
-    DEFAULT_HTTP_PORT,
-    MODEL_NAMES,
-    RPC_GENERATIONS,
-)
+from aioshelly.const import BLOCK_GENERATIONS, MODEL_NAMES, RPC_GENERATIONS
 from aioshelly.exceptions import (
     CustomPortNotSupported,
     DeviceConnectionError,
@@ -125,15 +120,14 @@ def device_updated(
 
 def print_device(device: BlockDevice | RpcDevice) -> None:
     """Print device data."""
-    port = getattr(device, "port", DEFAULT_HTTP_PORT)
     if not device.initialized:
         print()
-        print(f"** Device @ {device.ip_address}:{port} not initialized **")
+        print(f"** Device @ {device.ip_address}:{device.port} not initialized **")
         print()
         return
 
     model_name = MODEL_NAMES.get(device.model) or f"Unknown ({device.model})"
-    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port} **")
+    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{device.port} **")
     print()
 
     if device.gen in BLOCK_GENERATIONS:

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -14,7 +14,12 @@ from aiohttp import ClientSession
 
 from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions, get_info
-from aioshelly.const import BLOCK_GENERATIONS, MODEL_NAMES, RPC_GENERATIONS
+from aioshelly.const import (
+    BLOCK_GENERATIONS,
+    DEFAULT_HTTP_PORT,
+    MODEL_NAMES,
+    RPC_GENERATIONS,
+)
 from aioshelly.exceptions import (
     CustomPortNotSupported,
     DeviceConnectionError,
@@ -56,6 +61,7 @@ async def create_device(
 
 async def init_device(device: BlockDevice | RpcDevice) -> bool:
     """Initialize Shelly device."""
+    port = getattr(device, "port", DEFAULT_HTTP_PORT)
     try:
         await device.initialize()
     except FirmwareUnsupported as err:
@@ -63,13 +69,11 @@ async def init_device(device: BlockDevice | RpcDevice) -> bool:
     except InvalidAuthError as err:
         print(f"Invalid or missing authorization, error: {err!r}")
     except DeviceConnectionError as err:
-        print(
-            f"Error connecting to {device.ip_address}:{device.port}, " f"error: {err!r}"
-        )
+        print(f"Error connecting to {device.ip_address}:{port}, " f"error: {err!r}")
     except MacAddressMismatchError as err:
         print(f"MAC address mismatch, error: {err!r}")
     except WrongShellyGen:
-        print(f"Wrong Shelly generation for device {device.ip_address}:{device.port}")
+        print(f"Wrong Shelly generation for device {device.ip_address}:{port}")
     except CustomPortNotSupported:
         print("Custom port not supported for Gen1")
     else:
@@ -120,14 +124,15 @@ def device_updated(
 
 def print_device(device: BlockDevice | RpcDevice) -> None:
     """Print device data."""
+    port = getattr(device, "port", DEFAULT_HTTP_PORT)
     if not device.initialized:
         print()
-        print(f"** Device @ {device.ip_address}:{device.port} not initialized **")
+        print(f"** Device @ {device.ip_address}:{port} not initialized **")
         print()
         return
 
     model_name = MODEL_NAMES.get(device.model) or f"Unknown ({device.model})"
-    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{device.port} **")
+    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port} **")
     print()
 
     if device.gen in BLOCK_GENERATIONS:


### PR DESCRIPTION
Remove background `_async_init` task and `initialize` parameter:

- Move call to `initialize` for sleeping devices to user code, `_async_init` is no longer runs inside `aioshelly` which allows the user to call `initialize` when device is online and catch the errors.
- Add new status update type: `BlockUpdateType.ONLINE` & `RpcUpdateType.ONLINE` which inform the user that the device is online and he can call the `initialize`.
- Remove `initialize` parameter from device create. User is responsible to call `initialize`. This helps that we don't need to catch errors in two different places and can catch errors only on `initialize` method.
- Update examples

In the future we can use mDNS advertising from the device to call `initialize` which will help setting up sleeping devices which doesn't have `CoAP` unicast configured or `Outbound Websocket` so we can set it up for them.
