### PR TITLE
Add pre-commit autoupdate GH action

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,34 @@
+name: Pre-commit auto-update
+on:
+  schedule:
+    # Run on mondays at midnight
+    - cron: "0 0 * * 1"
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: |
+            Update versions of hooks in pre-commit
+            configs to latest version
+          labels: dependencies

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4.1.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Currently, we very rarely update the version of pre-commit hooks. For example, the `ruff` and `mypy` hooks are currently not up-to-date. I suggest adding GH action, which will run `pre-commit autoupdate` once a week and open PR if updates are available.