### PR TITLE
Update RPC shutdown description

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -218,7 +218,6 @@ class RpcDevice:
 
         This method will unsubscribe the update listener and disconnect the websocket.
 
-        To fully reverse a shutdown, call initialize() and subscribe_updates() again.
         """
         self._update_listener = None
         await self._disconnect_websocket()


### PR DESCRIPTION
The RPC shutdown process is not reversible since there is no method to reconnect the websocket.
Remove the comment to avoid incorrectly trying to reverse shutdown.