### PR TITLE
Add comment to explain the usage of the aioshelly BLE script

### DIFF
--- a/aioshelly/ble/const.py
+++ b/aioshelly/ble/const.py
@@ -21,6 +21,8 @@ DEFAULT_DURATION_MS = -1
 
 BLE_CODE = """
 // aioshelly BLE script 2.0
+// Script automatically installed by Home Assistant for Bluetooth proxy support
+// https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies
 const queueServeTimer = 100; // in ms, timer for events emitting
 const burstSendCount =  5; // number if events, emitted on timer event
 const maxQueue =  32; // if the queue exceeds the limit, all new events are ignored until it empties


### PR DESCRIPTION
Shelly is getting reports from users not able to delete a specific script and suggested to add a comment on top of the script body stating clearly that it is installed by HA
