### PR TITLE
Allow initialization for device with unsupported firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,7 @@ import aiohttp
 
 from aioshelly.block_device import COAP, BlockDevice
 from aioshelly.common import ConnectionOptions
-from aioshelly.exceptions import (
-    DeviceConnectionError,
-    FirmwareUnsupported,
-    InvalidAuthError,
-)
+from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 
 
 async def test_block_device():
@@ -47,9 +43,6 @@ async def test_block_device():
     async with aiohttp.ClientSession() as aiohttp_session, COAP() as coap_context:
         try:
             device = await BlockDevice.create(aiohttp_session, coap_context, options)
-        except FirmwareUnsupported as err:
-            print(f"Device firmware not supported, error: {repr(err)}")
-            return
         except InvalidAuthError as err:
             print(f"Invalid or missing authorization, error: {repr(err)}")
             return
@@ -76,11 +69,7 @@ from pprint import pprint
 import aiohttp
 
 from aioshelly.common import ConnectionOptions
-from aioshelly.exceptions import (
-    DeviceConnectionError,
-    FirmwareUnsupported,
-    InvalidAuthError,
-)
+from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 from aioshelly.rpc_device import RpcDevice, WsServer
 
 
@@ -93,9 +82,6 @@ async def test_rpc_device():
     async with aiohttp.ClientSession() as aiohttp_session:
         try:
             device = await RpcDevice.create(aiohttp_session, ws_context, options)
-        except FirmwareUnsupported as err:
-            print(f"Device firmware not supported, error: {repr(err)}")
-            return
         except InvalidAuthError as err:
             print(f"Invalid or missing authorization, error: {repr(err)}")
             return

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -147,7 +147,7 @@ class BlockDevice:
                 # Older devices has incompatible CoAP protocol (v1)
                 # Skip CoAP to avoid parsing errors
                 if self.firmware_supported:
-                    event_d: asyncio.Event = await self._coap_request("d")
+                    event_d = await self._coap_request("d")
                     # We need to wait for D to come in before we request S
                     # Or else we might miss the answer to D
                     await event_d.wait()

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -93,7 +93,7 @@ class BlockDevice:
             sub_id, self._coap_message_received
         )
         self._update_listener: Callable | None = None
-        self._coap_response_events: dict = {}
+        self._coap_response_events: dict[str, asyncio.Event] = {}
         self.initialized = False
         self._initializing = False
         self._last_error: ShellyError | None = None

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -81,7 +81,7 @@ class BlockDevice:
         self.aiohttp_session: ClientSession = aiohttp_session
         self.options: ConnectionOptions = options
         self.coap_d: dict[str, Any] | None = None
-        self.blocks: list = []
+        self.blocks: list[Block] = []
         self.coap_s: dict[str, Any] | None = None
         self._settings: dict[str, Any] | None = None
         self._shelly: dict[str, Any] | None = None

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1,6 +1,7 @@
 """Constants for aioshelly."""
 
 import asyncio
+import re
 
 import aiohttp
 
@@ -264,3 +265,5 @@ RPC_GENERATIONS = (GEN2, GEN3)
 DEFAULT_HTTP_PORT = 80
 PERIODIC_COAP_TYPE_CODE = 30
 END_OF_OPTIONS_MARKER = 0xFF
+
+FIRMWARE_PATTERN = re.compile(r"^(\d{8})")

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -35,10 +35,6 @@ class DeviceConnectionError(ShellyError):
     """Exception indicates device connection errors."""
 
 
-class FirmwareUnsupported(ShellyError):
-    """Raised if device firmware version is unsupported."""
-
-
 class InvalidAuthError(ShellyError):
     """Raised to indicate invalid or missing authentication error."""
 

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -129,7 +129,7 @@ def print_device(device: BlockDevice | RpcDevice) -> None:
         return
 
     model_name = MODEL_NAMES.get(device.model) or f"Unknown ({device.model})"
-    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port}**")
+    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port} **")
     print()
 
     if not device.firmware_supported:

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -23,7 +23,6 @@ from aioshelly.const import (
 from aioshelly.exceptions import (
     CustomPortNotSupported,
     DeviceConnectionError,
-    FirmwareUnsupported,
     InvalidAuthError,
     MacAddressMismatchError,
     ShellyError,
@@ -64,8 +63,6 @@ async def init_device(device: BlockDevice | RpcDevice) -> bool:
     port = getattr(device, "port", DEFAULT_HTTP_PORT)
     try:
         await device.initialize()
-    except FirmwareUnsupported as err:
-        print(f"Device firmware not supported, error: {err!r}")
     except InvalidAuthError as err:
         print(f"Invalid or missing authorization, error: {err!r}")
     except DeviceConnectionError as err:
@@ -132,8 +129,11 @@ def print_device(device: BlockDevice | RpcDevice) -> None:
         return
 
     model_name = MODEL_NAMES.get(device.model) or f"Unknown ({device.model})"
-    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port} **")
+    print(f"** {device.name} - {model_name}  @ {device.ip_address}:{port}**")
     print()
+
+    if not device.firmware_supported:
+        print(f"Device firmware not supported: {device.firmware_version}")
 
     if device.gen in BLOCK_GENERATIONS:
         print_block_device(cast(BlockDevice, device))


### PR DESCRIPTION
Allow initialization of a device with unsupported firmware so that we can use the device to trigger an update.
Added property to indicate if firmware is supported (`firmware_supported`)

Updated the `example.py` to indicate if firmware is not supported:

<ins>Gen1:</ins>
```
** shelly4pro-801234 - Shelly 4Pro  @ 192.168.1.49:80**

Device firmware not supported: 20190821-095050/v1.5.2@4148d2b7
```

<ins>Gen2:</ins>
```
** shellyplus1-a8032abe1234 - Shelly Plus 1  @ 192.168.1.70:80**

Device firmware not supported: 20210714-140932
```

(this Shelly pre-production firmware doesn't have a version only a date)