### PR TITLE
Align device shutdown

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -169,17 +169,17 @@ class BlockDevice:
             else:
                 self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            self.shutdown()
+            await self.shutdown()
             raise self._last_error from err
         except MacAddressMismatchError as err:
             self._last_error = err
             _LOGGER.debug("host %s: error: %r", ip, err)
-            self.shutdown()
+            await self.shutdown()
             raise
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            self.shutdown()
+            await self.shutdown()
             raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False
@@ -187,7 +187,7 @@ class BlockDevice:
         if self._update_listener:
             self._update_listener(self, BlockUpdateType.INITIALIZED)
 
-    def shutdown(self) -> None:
+    async def shutdown(self) -> None:
         """Shutdown device."""
         _LOGGER.debug("host %s: block device shutdown", self.ip_address)
         self._update_listener = None

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -181,3 +182,10 @@ async def update_outbound_ws(
         device: RpcDevice = await create_device(aiohttp_session, options, init, 2)
         print(f"Updating outbound weboskcet URL to {ws_url}")
         print(f"Restart required: {await device.update_outbound_websocket(ws_url)}")
+
+
+async def wait_for_keyboard_interrupt() -> None:
+    """Wait for keyboard interrupt (Ctrl-C)."""
+    sig_event = asyncio.Event()
+    signal.signal(signal.SIGINT, lambda _exit_code, _frame: sig_event.set())
+    await sig_event.wait()


### PR DESCRIPTION
Align device shutdown method so both block device and RPC device methods will be async, this makes it easier that devices has common interface (`create`, `initialize`, `subscribe_updates` & `shutdown`)

# Breaking change
For block device the method was changed to `async`, it should be awaited now.

## Before
```python
device.shutdown()
```

## After
```python
await device.shutdown()
```

Example code updated to call shutdown upon `ctrl-c` so we can test device shutdown.
