### PR TITLE
Fetch new status on device re-init

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -136,7 +136,13 @@ class BlockDevice:
             raise CustomPortNotSupported
 
         self._initializing = True
-        self.initialized = False
+
+        # First initialize may already have CoAP status from wakeup event
+        # If device is initialized again we need to fetch new CoAP status
+        if self.initialized:
+            self.initialized = False
+            self.coap_s = None
+
         ip = self.options.ip_address
         try:
             self._shelly = await get_info(

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -154,7 +154,13 @@ class RpcDevice:
             raise RuntimeError("Already initializing")
 
         self._initializing = True
-        self.initialized = False
+
+        # First initialize may already have status from wakeup event
+        # If device is initialized again we need to fetch new status
+        if self.initialized:
+            self.initialized = False
+            self._status = None
+
         ip = self.options.ip_address
         port = self.options.port
         try:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "10.0.0"
+VERSION = "10.0.1"
 
 with open("requirements.txt", encoding="utf-8") as file:  # noqa: PTH123
     requirements = file.read().splitlines()


### PR DESCRIPTION
Fix https://github.com/home-assistant/core/issues/118898

When a device status is updated while it is disconnected and we reconnect to the device we the status is not updated since we already have a status (this logic is needed for sleeping devices).

This makes sure that if we re-init a device we also fetch new status from it.
