### PR TITLE
Do not shutdown device upon errors

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -175,17 +175,14 @@ class BlockDevice:
             else:
                 self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            await self.shutdown()
             raise self._last_error from err
         except MacAddressMismatchError as err:
             self._last_error = err
             _LOGGER.debug("host %s: error: %r", ip, err)
-            await self.shutdown()
             raise
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            await self.shutdown()
             raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -183,7 +183,7 @@ class BlockDevice:
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
-            raise DeviceConnectionError(err) from err
+            raise self._last_error from err
         finally:
             self._initializing = False
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -200,7 +200,7 @@ class RpcDevice:
         except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)
-            raise DeviceConnectionError(err) from err
+            raise self._last_error from err
         finally:
             self._initializing = False
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -192,17 +192,14 @@ class RpcDevice:
         except InvalidAuthError as err:
             self._last_error = InvalidAuthError(err)
             _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)
-            await self._disconnect_websocket()
             raise
         except MacAddressMismatchError as err:
             self._last_error = err
             _LOGGER.debug("host %s:%s: error: %r", ip, port, err)
-            await self._disconnect_websocket()
             raise
         except (*CONNECT_ERRORS, RpcCallError) as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)
-            await self._disconnect_websocket()
             raise DeviceConnectionError(err) from err
         finally:
             self._initializing = False


### PR DESCRIPTION
This PR removes the calls to `shutdown` (Gen1) and `self._disconnect_websocket()` (same as `shutdown`, Gen2+) upon failures.
The `shutdown` process removes subscription to device async updates (updates which are pushed from the device by IP/MAC), this method is not reversible so after calling shutdown the only way to resubscribe to updates is to create a new device object.
However for sleeping devices we need the updates to continue flowing even if there is a failure since they trigger event to connect to the device.

Currently, If a sleeping device has an error on first time that we try to connect to it and it fails subsequent events from the device will be stopped so there won't be anything to try to trigger a new connection to the device on the next wakeup.
This logic was existing up to `aioshelly` 8.2.0 and removed by mistake (only the raise was supposed to move out of the condition)
https://github.com/home-assistant-libs/aioshelly/blob/e8058a54a38276050b6bd297954e041ea35082e3/aioshelly/block_device/device.py#L168-L170

However it would be better not to call shutdown at all and let the caller/user decide when to shutdown the device.

