### PR TITLE
Use aiohttp.ClientTimeout for passing timeouts

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 from http import HTTPStatus
 from typing import Any, ClassVar, cast
 
-from aiohttp import ClientResponse, ClientResponseError, ClientSession
+from aiohttp import ClientResponse, ClientResponseError, ClientSession, ClientTimeout
 from yarl import URL
 
 from ..common import ConnectionOptions, IpOrOptionsType, get_info, process_ip_or_options
@@ -54,6 +54,8 @@ BLOCK_VALUE_TYPE_STATUS = "S"  # (catch-all if no other fits)
 BLOCK_VALUE_TYPE_TEMPERATURE = "T"
 BLOCK_VALUE_TYPE_VOLTAGE = "V"
 
+
+HTTP_CALL_TIMEOUT_CLIENT_TIMEOUT = ClientTimeout(total=HTTP_CALL_TIMEOUT)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -311,7 +313,7 @@ class BlockDevice:
                 params=params,
                 auth=self.options.auth,
                 raise_for_status=True,
-                timeout=HTTP_CALL_TIMEOUT,
+                timeout=HTTP_CALL_TIMEOUT_CLIENT_TIMEOUT,
             )
         except ClientResponseError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from socket import gethostbyname
 from typing import Any
 
-from aiohttp import BasicAuth, ClientSession
+from aiohttp import BasicAuth, ClientSession, ClientTimeout
 from yarl import URL
 
 from .const import CONNECT_ERRORS, DEFAULT_HTTP_PORT, DEVICE_IO_TIMEOUT
@@ -19,6 +19,8 @@ from .exceptions import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+DEVICE_IO_TIMEOUT_CLIENT_TIMEOUT = ClientTimeout(total=DEVICE_IO_TIMEOUT)
 
 
 @dataclass
@@ -74,7 +76,7 @@ async def get_info(
         async with aiohttp_session.get(
             URL.build(scheme="http", host=ip_address, port=port, path="/shelly"),
             raise_for_status=True,
-            timeout=DEVICE_IO_TIMEOUT,
+            timeout=DEVICE_IO_TIMEOUT_CLIENT_TIMEOUT,
         ) as resp:
             result: dict[str, Any] = await resp.json()
     except CONNECT_ERRORS as err:


### PR DESCRIPTION
Calling timeout with float is deprecated, and the typing now reflects the deprecation. use aiohttp.ClientTimeout instead