### PR TITLE
Don't use `GetComponents` if firmware doesn't support it

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -281,3 +281,4 @@ END_OF_OPTIONS_MARKER = 0xFF
 FIRMWARE_PATTERN = re.compile(r"^(\d{8})")
 
 VIRTUAL_COMPONENTS = ("boolean", "button", "enum", "number", "text")
+VIRTUAL_COMPONENTS_MIN_FIRMWARE = 20240213

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -281,4 +281,5 @@ END_OF_OPTIONS_MARKER = 0xFF
 FIRMWARE_PATTERN = re.compile(r"^(\d{8})")
 
 VIRTUAL_COMPONENTS = ("boolean", "button", "enum", "number", "text")
+# Firmware 1.2.0 release date
 VIRTUAL_COMPONENTS_MIN_FIRMWARE = 20240213


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/issues/123440

The integration uses `component_added` and `component_removed` events so firmware 1.2.0 is the minimum version to ensure full compatibility with virtual components.

![obraz](https://github.com/user-attachments/assets/ac7f1c0e-6bea-4b8a-b1ac-4eb662167aa8)


Tested with firmware 1.1.0 and 1.2.0.