### PR TITLE
Optimize RPC device dict merge

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -44,14 +44,16 @@ from .wsrpc import WsRPC, WsServer
 _LOGGER = logging.getLogger(__name__)
 
 
-def mergedicts(dict1: dict, dict2: dict) -> dict:
-    """Deep dicts merge."""
-    result = dict(dict1)
-    result.update(dict2)
-    for key, value in result.items():
-        if isinstance(value, dict) and isinstance(dict1.get(key), dict):
-            result[key] = mergedicts(dict1[key], value)
-    return result
+def mergedicts(dest: dict, source: dict) -> None:
+    """Deep dicts merge.
+
+    The destination dict is updated with the source dict.
+    """
+    for k, v in source.items():
+        if k in dest and type(v) is dict:  # - only accepts `dict` type
+            mergedicts(dest[k], v)
+        else:
+            dest[k] = v
 
 
 class RpcUpdateType(Enum):
@@ -123,7 +125,7 @@ class RpcDevice:
                 self._status = params
                 update_type = RpcUpdateType.STATUS
             elif method == "NotifyStatus" and self._status is not None:
-                self._status = dict(mergedicts(self._status, params))
+                mergedicts(self._status, params)
                 update_type = RpcUpdateType.STATUS
             elif method == "NotifyEvent":
                 self._event = params

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,5 @@ types-requests
 pre-commit==3.8.0
 tox==4.17.1
 wheel==0.44.0
+pytest==8.3.2
+pytest-asyncio==0.23.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ tox==4.17.1
 wheel==0.44.0
 pytest==8.3.2
 pytest-asyncio==0.23.8
+pytest-cov==5.0.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,6 +29,14 @@ lint.ignore = [
 "tools/*" = [
     "T201",      # `print` found
 ]
+"tests/**/*" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "S101",
+]
 
 [lint.mccabe]
 max-complexity = 18

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for aioshelly."""

--- a/tests/rpc_device/__init__.py
+++ b/tests/rpc_device/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for RPC device."""

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -1,0 +1,11 @@
+"""Tests for rpc_device.device module."""
+
+from aioshelly.rpc_device.device import mergedicts
+
+
+def test_mergedicts() -> None:
+    """Test the recursive dict merge."""
+    dest = {"a": 1, "b": {"c": 2, "d": 3}}
+    source = {"b": {"c": 4, "e": 5}}
+    mergedicts(dest, source)
+    assert dest == {"a": 1, "b": {"c": 4, "d": 3, "e": 5}}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py311, py312, lint, mypy
+envlist = py311, py312, lint, mypy, tests
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
   3.11: py311, lint, mypy
-  3.12: py312
+  3.12: py312, tests
 
 [testenv:lint]
 basepython = python3
@@ -26,3 +26,12 @@ commands =
 deps =
   -rrequirements.txt
   -rrequirements_lint.txt
+
+[testenv:tests]
+basepython = python3
+ignore_errors = True
+commands =
+  python -m pytest --cov=aioshelly --cov-report=xml --cov-report=term-missing
+deps =
+  -rrequirements.txt
+  -rrequirements_dev.txt


### PR DESCRIPTION
I noticed the dict merge makes two copies of the destination dict, one inside `mergedicts` and one outside.  It doesn't look like we need to make a make a copy in the first place since we never compare the old and new data anywhere.

This is a ~92% speed up

![dict_merge](https://github.com/user-attachments/assets/c9cfb4d3-21b7-4330-aa3f-e235eabcc3ab)
