### PR TITLE
Fix duplicate timeout in call_rpc

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -349,8 +349,7 @@ class RpcDevice:
     ) -> dict[str, Any]:
         """Call RPC method."""
         try:
-            async with asyncio.timeout(DEVICE_IO_TIMEOUT):
-                return await self._wsrpc.call(method, params)
+            return await self._wsrpc.call(method, params, DEVICE_IO_TIMEOUT)
         except (InvalidAuthError, RpcCallError) as err:
             self._last_error = err
             raise


### PR DESCRIPTION
There is already a timeout in wsrpc.call