### PR TITLE
Block notifications if the device is not initialized

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -147,11 +147,19 @@ class RpcDevice:
         elif method == NOTIFY_WS_CLOSED:
             update_type = RpcUpdateType.DISCONNECTED
 
-        if source is RPCSource.SERVER and not self.initialized:
+        # Battery operated device, inform listener that device is online
+        if (
+            source is RPCSource.SERVER
+            and not self.initialized
+            and not self._initializing
+        ):
             self._update_listener(self, RpcUpdateType.ONLINE)
             return
 
-        self._update_listener(self, update_type)
+        # If the device isn't initialized, avoid sending updates
+        # as it may be in the process of initializing.
+        if self.initialized:
+            self._update_listener(self, update_type)
 
     @property
     def ip_address(self) -> str:


### PR DESCRIPTION
Attempt to fix: https://github.com/home-assistant/core/issues/123399#issuecomment-2294924493