### PR TITLE
Reduce overhead to make RPC calls

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -298,7 +298,7 @@ class WsRPC(WsBase):
                 return
 
             call = self._calls.pop(frame_id)
-            if not call.resolve.cancelled():
+            if not call.resolve.done():
                 call.resolve.set_result(frame)
 
         else:


### PR DESCRIPTION
We can avoid the asyncio.timeout context since we already are awaiting a future and schedule a timeout on the future that is being awaited instead. This saves a bit of latency which helps with being able to connect in time to sleepy devices for the few seconds they are awake.