### PR TITLE
Switch fetching device info to go over the websocket for RPC devices

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -285,18 +285,18 @@ class RpcDevice:
 
     async def _init_calls(self) -> None:
         """Make calls needed to initialize the device."""
-        calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
-        if fetch_status := self._status is None:
-            calls.append(("Shelly.GetStatus", None))
+        calls: list[tuple[str, dict[str, Any] | None]] = []
         if fetch_dynamic := self._supports_dynamic_components():
             calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
+        if fetch_status := self._status is None:
+            calls.append(("Shelly.GetStatus", None))
+        calls.append(("Shelly.GetConfig", None))
         results = await self.call_rpc_multiple(calls)
-        self._config = results[0]
-        if fetch_status:
-            self._status = results[1]
         if fetch_dynamic:
-            dynamic_idx = 2 if fetch_status else 1
-            self._parse_dynamic_components(results[dynamic_idx])
+            self._parse_dynamic_components(results.pop())
+        if fetch_status:
+            self._status = results.pop()
+        self._config = results[0]
 
     async def script_list(self) -> list[ShellyScript]:
         """Get a list of scripts from 'Script.List'."""

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -291,11 +291,11 @@ class RpcDevice:
         if fetch_dynamic := self._supports_dynamic_components():
             calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
         results = await self.call_rpc_multiple(calls)
-        if fetch_dynamic:
-            self._parse_dynamic_components(results.pop())
+        self._config = results.pop(0)
         if fetch_status:
-            self._status = results.pop()
-        self._config = results[0]
+            self._status = results.pop(0)
+        if fetch_dynamic:
+            self._parse_dynamic_components(results.pop(0))
 
     async def script_list(self) -> list[ShellyScript]:
         """Get a list of scripts from 'Script.List'."""

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -281,11 +281,11 @@ class RpcDevice:
         if fetch_dynamic := self._supports_dynamic_components():
             calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
         results = await self.call_rpc_multiple(calls)
-        self._config = results.pop()
+        self._config = results.pop(0)
         if fetch_status:
-            self._status = results.pop()
+            self._status = results.pop(0)
         if fetch_dynamic:
-            self._parse_dynamic_components(results.pop())
+            self._parse_dynamic_components(results.pop(0))
 
     async def script_list(self) -> list[ShellyScript]:
         """Get a list of scripts from 'Script.List'."""

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -274,7 +274,7 @@ class RpcDevice:
 
     async def _init_calls(self) -> None:
         """Make calls needed to initialize the device."""
-        self._shelly = await self.call_rpc("Shelly.GetInfo")
+        self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
         if fetch_status := self._status is None:
             calls.append(("Shelly.GetStatus", None))

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -270,7 +270,7 @@ class RpcDevice:
         """Make calls needed to initialize the device."""
         # Shelly.GetDeviceInfo is the only RPC call that does not
         # require auth, so we must do a separate call here to get
-        # the auth_domain/id
+        # the auth_domain/id so we can enable auth for the rest of the calls
         self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
         if self.options.username and self.options.password:
             self._wsrpc.set_auth_data(

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -197,12 +197,6 @@ class RpcDevice:
         ip = self.options.ip_address
         port = self.options.port
         try:
-            if self.options.username and self.options.password:
-                self._wsrpc.set_auth_data(
-                    self.shelly["auth_domain"],
-                    self.options.username,
-                    self.options.password,
-                )
             async with asyncio.timeout(DEVICE_IO_TIMEOUT):
                 await self._wsrpc.connect(self.aiohttp_session)
             await self._init_calls()
@@ -279,6 +273,12 @@ class RpcDevice:
         # change this to fetch all data in one call once call_rpc_multiple
         # can be refactored to return errors instead of raising them.
         self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
+        if self.options.username and self.options.password:
+            self._wsrpc.set_auth_data(
+                self.shelly.get("auth_domain", self.shelly["id"]),
+                self.options.username,
+                self.options.password,
+            )
 
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
         if fetch_status := self._status is None:

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -285,12 +285,11 @@ class RpcDevice:
 
     async def _init_calls(self) -> None:
         """Make calls needed to initialize the device."""
-        calls: list[tuple[str, dict[str, Any] | None]] = []
-        if fetch_dynamic := self._supports_dynamic_components():
-            calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
+        calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
         if fetch_status := self._status is None:
             calls.append(("Shelly.GetStatus", None))
-        calls.append(("Shelly.GetConfig", None))
+        if fetch_dynamic := self._supports_dynamic_components():
+            calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
         results = await self.call_rpc_multiple(calls)
         if fetch_dynamic:
             self._parse_dynamic_components(results.pop())

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -274,7 +274,12 @@ class RpcDevice:
 
     async def _init_calls(self) -> None:
         """Make calls needed to initialize the device."""
+        # _supports_dynamic_components() needs _shelly to be set
+        # so we need to fetch it first. In the future we could
+        # change this to fetch all data in one call once call_rpc_multiple
+        # can be refactored to return errors instead of raising them.
         self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
+
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
         if fetch_status := self._status is None:
             calls.append(("Shelly.GetStatus", None))

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -391,7 +391,7 @@ class RpcDevice:
 
     async def call_rpc_multiple(
         self, calls: Iterable[tuple[str, dict[str, Any] | None]]
-    ) -> tuple[dict[str, Any], ...]:
+    ) -> list[dict[str, Any]]:
         """Call RPC method."""
         try:
             return await self._wsrpc.calls(calls, DEVICE_IO_TIMEOUT)

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -268,10 +268,9 @@ class RpcDevice:
 
     async def _init_calls(self) -> None:
         """Make calls needed to initialize the device."""
-        # _supports_dynamic_components() needs _shelly to be set
-        # so we need to fetch it first. In the future we could
-        # change this to fetch all data in one call once call_rpc_multiple
-        # can be refactored to return errors instead of raising them.
+        # Shelly.GetDeviceInfo is the only RPC call that does not
+        # require auth, so we must do a separate call here to get
+        # the auth_domain/id
         self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
         if self.options.username and self.options.password:
             self._wsrpc.set_auth_data(

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -216,7 +216,7 @@ class RpcDevice:
 
             async with asyncio.timeout(DEVICE_IO_TIMEOUT):
                 await self._wsrpc.connect(self.aiohttp_session)
-                await self._init_calls()
+            await self._init_calls()
         except InvalidAuthError as err:
             self._last_error = InvalidAuthError(err)
             _LOGGER.debug("host %s:%s: error: %r", ip, port, self._last_error)

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -480,6 +480,9 @@ class WsRPC(WsBase):
                 with contextlib.suppress(asyncio.CancelledError):
                     call.resolve.cancel()
                     await call.resolve
+                # Ensure the call is removed from the calls dict
+                # on failure
+                self._calls.pop(call.call_id, None)
             raise DeviceConnectionError(call) from exc
 
         if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -135,10 +135,6 @@ class RPCCall:
         "has_result",
     )
 
-    # RPCCall are never returned to a higher scope
-    # unless result is set
-    result: dict[str, dict[str, Any]] = None  # type: ignore[assignment]
-
     def __init__(
         self,
         call_id: int,
@@ -156,6 +152,10 @@ class RPCCall:
         self.dst = session.dst
         self.resolve = resolve
         self.has_result = False
+        # RPCCall are never returned to a higher scope
+        # unless result is set so we do not type it to
+        # allow None to avoid lots of asserts in the code
+        self.result: dict[str, dict[str, Any]] = None  # type: ignore[assignment]
 
     @property
     def request_frame(self) -> dict[str, Any]:

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -65,8 +65,7 @@ def _receive_json_or_raise(msg: WSMessage) -> RPCResponseType:
             data: RPCResponseType = json_loads(msg.data)
         except ValueError as err:
             raise InvalidMessage(f"Received invalid JSON: {msg.data}") from err
-        else:
-            return data
+        return data
 
     if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
         raise ConnectionClosed("Connection was closed.")

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -315,7 +315,7 @@ class WsRPC(WsBase):
             assert self._client
 
         try:
-            while not self._client.closed:
+            while True:
                 try:
                     msg = await self._client.receive()
                     frame = _receive_json_or_raise(msg)
@@ -335,8 +335,10 @@ class WsRPC(WsBase):
                     _LOGGER.exception("Unexpected error while receiving message")
                     raise
 
-                if not self._client.closed:
-                    self.handle_frame(RPCSource.CLIENT, frame)
+                if self._client.closed:
+                    break
+
+                self.handle_frame(RPCSource.CLIENT, frame)
         finally:
             _LOGGER.debug(
                 "Websocket client connection from %s:%s closed",

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -404,6 +404,10 @@ class WsRPC(WsBase):
         # Try request with initial/last call auth data
         all_successful, results = await self._rpc_calls(calls, timeout)
         if all_successful:
+            # If all_successful, return results immediately
+            # mypy does not know that .result is never
+            # None when all_successful is True so we need
+            # to ignore the type check here
             return [call.result for call in results]  # type: ignore[misc]
 
         # Partial success, try to update auth and retry

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -493,7 +493,7 @@ class WsRPC(WsBase):
         if TYPE_CHECKING:
             assert self._client
 
-        await self._client.send_json(data, dumps=json_dumps)
+        await self._client.send_str(json_dumps(data))
 
 
 class WsServer(WsBase):

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -469,7 +469,7 @@ class WsRPC(WsBase):
                 # Wait for all the responses
                 for call in to_send:
                     response = await call.resolve
-                    if "result" in response:
+                    if "result" not in response:
                         all_successful = False
                         continue
                     call.result = response["result"]


### PR DESCRIPTION
Avoid the REST call since we have to create another connection to the device when we do the rest call which will stay open for a bit. By doing everything of the websocket we put less pressure on the device, and setup is a bit faster