### PR TITLE
Use `device_id` as `realm` value for auth

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -209,7 +209,7 @@ class RpcDevice:
                     raise InvalidAuthError("auth missing and required")  # noqa: TRY301
 
                 self._wsrpc.set_auth_data(
-                    self.shelly["auth_domain"],
+                    self.shelly["id"],
                     self.options.username,
                     self.options.password,
                 )


### PR DESCRIPTION
This will fix WallDisplay support with authorization enabled. WallDisplay doesn't return `auth_domain` value in response to `/shelly`.