### PR TITLE
Add a separate timeout error exception class

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -186,7 +186,7 @@ class BlockDevice:
             raise
         except TimeoutError as err:
             self._last_error = DeviceConnectionTimeoutError(err)
-            _LOGGER.debug("host %s: error: %r", ip, self._last_error)
+            _LOGGER.debug("host %s: timeout error: %r", ip, self._last_error)
             raise self._last_error from err
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)

--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -29,6 +29,7 @@ from ..const import (
 from ..exceptions import (
     CustomPortNotSupported,
     DeviceConnectionError,
+    DeviceConnectionTimeoutError,
     InvalidAuthError,
     MacAddressMismatchError,
     NotInitialized,
@@ -183,6 +184,10 @@ class BlockDevice:
             self._last_error = err
             _LOGGER.debug("host %s: error: %r", ip, err)
             raise
+        except TimeoutError as err:
+            self._last_error = DeviceConnectionTimeoutError(err)
+            _LOGGER.debug("host %s: error: %r", ip, self._last_error)
+            raise self._last_error from err
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             _LOGGER.debug("host %s: error: %r", ip, self._last_error)
@@ -234,9 +239,12 @@ class BlockDevice:
             async with asyncio.timeout(DEVICE_IO_TIMEOUT):
                 event = await self._coap_request("s")
                 await event.wait()
+        except TimeoutError as err:
+            self._last_error = DeviceConnectionTimeoutError(err)
+            raise self._last_error from err
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
-            raise DeviceConnectionError from err
+            raise self._last_error from err
 
     def _update_d(self, data: dict[str, Any]) -> None:
         """Device update from cit/d call."""
@@ -322,7 +330,19 @@ class BlockDevice:
                 raise InvalidAuthError(err) from err
 
             self._last_error = DeviceConnectionError(err)
-            raise DeviceConnectionError from err
+            raise self._last_error from err
+        except TimeoutError as err:
+            self._last_error = DeviceConnectionTimeoutError(err)
+            if retry:
+                _LOGGER.debug(
+                    "host %s: http request timeout: %r", host, self._last_error
+                )
+                return await self.http_request(method, path, params, retry=False)
+
+            _LOGGER.debug(
+                "host %s: http request retry timeout: %r", host, self._last_error
+            )
+            raise self._last_error from err
         except CONNECT_ERRORS as err:
             self._last_error = DeviceConnectionError(err)
             if retry:
@@ -332,7 +352,7 @@ class BlockDevice:
             _LOGGER.debug(
                 "host %s: http request retry error: %r", host, self._last_error
             )
-            raise DeviceConnectionError from err
+            raise self._last_error from err
 
         resp_json = await resp.json(loads=json_loads)
         _LOGGER.debug("aiohttp response: %s", resp_json)

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1,6 +1,5 @@
 """Constants for aioshelly."""
 
-import asyncio
 import re
 from dataclasses import dataclass
 
@@ -8,12 +7,7 @@ import aiohttp
 
 from .exceptions import DeviceConnectionError
 
-CONNECT_ERRORS = (
-    aiohttp.ClientError,
-    asyncio.TimeoutError,
-    DeviceConnectionError,
-    OSError,
-)
+CONNECT_ERRORS = (aiohttp.ClientError, DeviceConnectionError, OSError)
 
 
 # Gen1 CoAP based models

--- a/aioshelly/exceptions.py
+++ b/aioshelly/exceptions.py
@@ -35,6 +35,10 @@ class DeviceConnectionError(ShellyError):
     """Exception indicates device connection errors."""
 
 
+class DeviceConnectionTimeoutError(ShellyError):
+    """Exception indicates device connection timeout errors."""
+
+
 class InvalidAuthError(ShellyError):
     """Raised to indicate invalid or missing authentication error."""
 

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -36,6 +36,7 @@ from ..const import DEFAULT_HTTP_PORT, NOTIFY_WS_CLOSED, WS_API_URL, WS_HEARTBEA
 from ..exceptions import (
     ConnectionClosed,
     DeviceConnectionError,
+    DeviceConnectionTimeoutError,
     InvalidAuthError,
     InvalidMessage,
     RpcCallError,
@@ -484,7 +485,7 @@ class WsRPC(WsBase):
                 # Ensure the call is removed from the calls dict
                 # on failure
                 self._calls.pop(call.call_id, None)
-            raise DeviceConnectionError(call) from exc
+            raise DeviceConnectionTimeoutError(sent_calls) from exc
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             for call in sent_calls:

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -24,6 +24,7 @@ from aioshelly.const import (
 from aioshelly.exceptions import (
     CustomPortNotSupported,
     DeviceConnectionError,
+    DeviceConnectionTimeoutError,
     InvalidAuthError,
     MacAddressMismatchError,
     ShellyError,
@@ -66,6 +67,11 @@ async def init_device(device: BlockDevice | RpcDevice) -> bool:
         await device.initialize()
     except InvalidAuthError as err:
         print(f"Invalid or missing authorization, error: {err!r}")
+    except DeviceConnectionTimeoutError as err:
+        print(
+            f"Timeout error connecting to {device.ip_address}:{port}, "
+            f"error: {err!r}"
+        )
     except DeviceConnectionError as err:
         print(f"Error connecting to {device.ip_address}:{port}, " f"error: {err!r}")
     except MacAddressMismatchError as err:


### PR DESCRIPTION
When `DeviceConnectionError` is raised, its not immediately obvious that when its a timeout problem.

`DeviceConnectionTimeoutError` is a subclass of `DeviceConnectionError` to ensure backwards compat.

related issue https://github.com/home-assistant/core/issues/124888