### PR TITLE
Use extended timeouts for status calls that may take a while

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -869,10 +869,17 @@ GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION = {
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
 # Timeout used for Device IO
-DEVICE_IO_TIMEOUT = 10
+DEVICE_IO_TIMEOUT = 10.0
+
+# Timeout used for polling
+DEVICE_POLLING_TIMEOUT = 45.0
+
+# Timeout used for initial connection calls
+# after the connection has been established
+DEVICE_INIT_TIMEOUT = 30.0
 
 # Timeout used for HTTP calls
-HTTP_CALL_TIMEOUT = 10
+HTTP_CALL_TIMEOUT = 10.0
 
 WS_HEARTBEAT = 55
 

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -872,7 +872,7 @@ MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 DEVICE_IO_TIMEOUT = 10.0
 
 # Timeout used for polling
-DEVICE_POLLING_TIMEOUT = 45.0
+DEVICE_POLL_TIMEOUT = 45.0
 
 # Timeout used for initial connection calls
 # after the connection has been established

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -272,11 +272,11 @@ class RpcDevice:
 
     async def poll(self) -> None:
         """Poll device for calls that do not receive push updates."""
-        calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
+        calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetStatus", None)]
         if fetch_dynamic := self._supports_dynamic_components():
             calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
         results = await self.call_rpc_multiple(calls, DEVICE_POLLING_TIMEOUT)
-        self._config = results[0]
+        self._status = results[0]
         if fetch_dynamic:
             self._parse_dynamic_components(results[1])
 

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -273,8 +273,7 @@ class RpcDevice:
     async def poll(self) -> None:
         """Poll device for calls that do not receive push updates."""
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetStatus", None)]
-        has_dynamic = bool(self._dynamic_components)
-        if has_dynamic:
+        if has_dynamic := bool(self._dynamic_components):
             # Only poll dynamic components if we have them
             calls.append(("Shelly.GetComponents", {"dynamic_only": True}))
         results = await self.call_rpc_multiple(calls, DEVICE_POLL_TIMEOUT)

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -395,7 +395,7 @@ class WsRPC(WsBase):
         raise InvalidAuthError(msg)
 
     async def calls(
-        self, calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: int = 10
+        self, calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: float = 10.0
     ) -> list[dict[str, Any]]:
         """Websocket RPC calls."""
         # Try request with initial/last call auth data
@@ -441,7 +441,7 @@ class WsRPC(WsBase):
         return successful
 
     async def _rpc_calls(
-        self, rpc_calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: int
+        self, rpc_calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: float
     ) -> tuple[bool, list[RPCCall]]:
         """Websocket RPC call.
 


### PR DESCRIPTION
In https://github.com/home-assistant/core/issues/124888 we see that GetStatus can take up to 22+ seconds to respond.

```
2024-08-30 01:12:02.409 DEBUG (MainThread) [aioshelly.rpc_device.wsrpc] send(192.168.88.31:80): {'id': 760, 'method': 'Shelly.GetStatus', 'src': 'aios-139875229921600', 'dst': 'shellyplus2pm-48551998da98'}
```
```
2024-08-30 01:12:24.672 DEBUG (MainThread) [aioshelly.rpc_device.wsrpc] recv(192.168.88.31:80): {'id': 760, 'src': 'shellyplus2pm-48551998da98', 'dst': 'aios-139875229921600', 'result': {'ble': {}, 'cloud': {'connected': False}, 'input:0': {'id': 0, 'state': True}, 'input:1': {'id': 1, 'state': False}, 'mqtt': {'connected': False}, 'script:1': {'id': 1, 'running': False, 'mem_free': 25200}, 'switch:0': {'id': 0, 'source': 'switch', 'output': False, 'apower': 0.0, 'voltage': 229.1, 'freq': 50.0, 'current': 0.0, 'pf': 0.0, 'aenergy': {'total': 1019.328, 'by_minute': [0.0, 0.0, 0.0], 'minute_ts': 1724973120}, 'ret_aenergy': {'total': 0.0, 'by_minute': [0.0, 0.0, 0.0], 'minute_ts': 1724973120}, 'temperature': {'tC': 54.4, 'tF': 129.9}}, 'switch:1': {'id': 1, 'source': 'switch', 'output': False, 'apower': 0.0, 'voltage': 229.1, 'freq': 50.0, 'current': 0.0, 'pf': 0.0, 'aenergy': {'total': 5295.319, 'by_minute': [0.0, 0.0, 0.0], 'minute_ts': 1724973120}, 'ret_aenergy': {'total': 0.0, 'by_minute': [0.0, 0.0, 0.0], 'minute_ts': 1724973120}, 'temperature': {'tC': 54.4, 'tF': 129.9}}, 'sys': {'mac': '48551998DA98', 'restart_required': False, 'time': '01:12', 'unixtime': 1724973122, 'uptime': 886205, 'ram_size': 252344, 'ram_free': 135444, 'fs_size': 393216, 'fs_free': 98304, 'cfg_rev': 55, 'kvs_rev': 6, 'schedule_rev': 0, 'webhook_rev': 0, 'available_updates': {}, 'reset_reason': 3}, 'wifi': {'sta_ip': '192.168.88.31', 'status': 'got ip', 'ssid': 'MikroTik-Sec', 'rssi': -56}, 'ws': {'connected': False}}}
```

HA PR https://github.com/home-assistant/core/pull/124893