### PR TITLE
Add Shelly DALI Dimmer Gen3

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -113,6 +113,7 @@ MODEL_1PM_GEN3 = "S3SW-001P16EU"
 MODEL_1PM_MINI_G3 = "S3SW-001P8EU"
 MODEL_2PM_G3 = "S3SW-002P16EU"
 MODEL_BLU_GATEWAY_GEN3 = "S3GW-1DBT001"
+MODEL_DALI_DIMMER_GEN3 = "S3DM-0A1WW"
 MODEL_DIMMER_10V_GEN3 = "S3DM-0010WW"
 MODEL_EM_G3 = "S3EM-002CXCEU"
 MODEL_HT_G3 = "S3SN-0U12A"
@@ -844,6 +845,13 @@ DEVICES = {
     MODEL_2PM_G3: ShellyDevice(
         model="S3SW-002P16EU",
         name="Shelly 2PM Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
+    MODEL_DALI_DIMMER_GEN3: ShellyDevice(
+        model="S3DM-0A1WW",
+        name="Shelly DALI Dimmer Gen3",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
         supported=True,


### PR DESCRIPTION
Adding this new device:
https://www.shelly.com/products/shelly-dali-dimmer-gen3
https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyDDimmerG3
![image](https://github.com/user-attachments/assets/b54cb002-df97-439b-89ae-333e1e3e3a23)
