### PR TITLE
Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4.2.2
         with:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py311, py312, lint, mypy, tests
+envlist = py311, py312, py313, lint, mypy, tests
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
   3.11: py311, lint, mypy
   3.12: py312, tests
+  3.13: py313, tests
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
I'm testing aioshelly with Python 3.13 and https://github.com/home-assistant/core/pull/129442

So far everything looks good