### PR TITLE
Fix MacAddressMismatchError check for RPC devices

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -294,6 +294,11 @@ class RpcDevice:
                 self.options.password,
             )
 
+        mac = self.shelly["mac"]
+        device_mac = self.options.device_mac
+        if device_mac and device_mac != mac:
+            raise MacAddressMismatchError(f"Input MAC: {device_mac}, Shelly MAC: {mac}")
+
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]
         if fetch_status := self._status is None:
             calls.append(("Shelly.GetStatus", None))


### PR DESCRIPTION
Fixes regression found at https://github.com/home-assistant/core/issues/130696