### PR TITLE
Restore use of `find_packages` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
@@ -21,7 +21,7 @@ setup(
     description="Asynchronous library to control Shelly devices.",
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
-    packages=["aioshelly"],
+    packages=find_packages(exclude=["tests", "tools"]),
     python_requires=">=3.11",
     package_data={"aioshelly": ["py.typed"]},
     zip_safe=True,


### PR DESCRIPTION
Related to https://github.com/home-assistant-libs/aioshelly/pull/705