### PR TITLE
Add Shelly 3EM-63 Gen3 model

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -113,6 +113,7 @@ MODEL_1_MINI_G3 = "S3SW-001X8EU"
 MODEL_1PM_GEN3 = "S3SW-001P16EU"
 MODEL_1PM_MINI_G3 = "S3SW-001P8EU"
 MODEL_2PM_G3 = "S3SW-002P16EU"
+MODEL_3EM_63_GEN3 = "S3EM-003CXCEU63"
 MODEL_BLU_GATEWAY_GEN3 = "S3GW-1DBT001"
 MODEL_DALI_DIMMER_GEN3 = "S3DM-0A1WW"
 MODEL_DIMMER_10V_GEN3 = "S3DM-0010WW"
@@ -858,6 +859,13 @@ DEVICES = {
     MODEL_2PM_G3: ShellyDevice(
         model="S3SW-002P16EU",
         name="Shelly 2PM Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
+    MODEL_3EM_63_GEN3: ShellyDevice(
+        model="S3EM-003CXCEU63",
+        name="Shelly 3EM-63 Gen3",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
         supported=True,


### PR DESCRIPTION
Output from `/shelly`:
```
{"name":null,"id":"shelly3em63g3-redacted","mac":"redacted","slot":1,"model":"S3EM-003CXCEU63","gen":3,"fw_id":"20241114-135317/1.4.99-3emg3prod1-g2299489","ver":"1.4.99-3emg3prod1","app":"S3EMG3","auth_en":false,"auth_domain":null,"profile":"triphase"}
```