### PR TITLE
Catch one more connection exception

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -354,7 +354,12 @@ class WsRPC(WsBase):
                         self._port,
                         err,
                     )
-                except ConnectionClosed:
+                except (ConnectionClosed, client_exceptions.ClientConnectionResetError):
+                    _LOGGER.debug(
+                        "Connection issue with device %s:%s",
+                        self._ip_address,
+                        self._port,
+                    )
                     break
                 except Exception:
                     _LOGGER.exception("Unexpected error while receiving message")


### PR DESCRIPTION
```
2024-12-30 19:44:45.247 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aioshelly/rpc_device/wsrpc.py", line 345, in _rx_msgs
    msg = await self._client.receive()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client_ws.py", line 376, in receive
    await self.pong(msg.data)
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client_ws.py", line 232, in pong
    await self._writer.send_frame(message, WSMsgType.PONG)
  File "/usr/local/lib/python3.13/site-packages/aiohttp/_websocket/writer.py", line 125, in send_frame
    raise ClientConnectionResetError("Cannot write to closing transport")
aiohttp.client_exceptions.ClientConnectionResetError: Cannot write to closing transport
```