### PR TITLE
Add `timeout` parameter for `call_rpc` method

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -422,10 +422,13 @@ class RpcDevice:
         return bool(self.shelly["auth_en"])
 
     async def call_rpc(
-        self, method: str, params: dict[str, Any] | None = None
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = DEVICE_IO_TIMEOUT,
     ) -> dict[str, Any]:
         """Call RPC method."""
-        return (await self.call_rpc_multiple(((method, params),)))[0]
+        return (await self.call_rpc_multiple(((method, params),), timeout))[0]
 
     async def call_rpc_multiple(
         self,


### PR DESCRIPTION
When I call `BluTRV.Call` via `call_rpc` from an integration sometimes the requests ends with `DeviceConnectionError` because the timeout is too short for BLU TRV. I suggest to add `timeout` parameter for `call_rpc` method and pass it to the `call_rpc_multiple` method.

