### PR TITLE
Add `call_blu_trv` method

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1003,6 +1003,9 @@ UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
+# Timeout used for BLU TRV
+BLU_TRV_TIMEOUT = 20.0
+
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10.0
 

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1003,8 +1003,8 @@ UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
-# Timeout used for BLU TRV
-BLU_TRV_TIMEOUT = 40.0
+# Timeout used for BLU TRV, 60 seconds confirmed with Shelly team
+BLU_TRV_TIMEOUT = 60.0
 
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10.0

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1004,7 +1004,7 @@ UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
 # Timeout used for BLU TRV
-BLU_TRV_TIMEOUT = 20.0
+BLU_TRV_TIMEOUT = 40.0
 
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10.0

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -423,7 +423,7 @@ class RpcDevice:
         return bool(self.shelly["auth_en"])
 
     async def call_blu_trv(
-        self, idx: int, method: str, params: dict[str, Any]
+        self, method: str, idx: int, params: dict[str, Any]
     ) -> dict[str, Any]:
         """Call BLU TRV."""
         call: tuple[str, dict[str, Any]] = (

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -20,6 +20,7 @@ from ..common import (
 from ..const import (
     BLU_TRV_IDENTIFIER,
     BLU_TRV_MODEL_ID,
+    BLU_TRV_TIMEOUT,
     CONNECT_ERRORS,
     DEVICE_INIT_TIMEOUT,
     DEVICE_IO_TIMEOUT,
@@ -420,6 +421,16 @@ class RpcDevice:
             raise WrongShellyGen
 
         return bool(self.shelly["auth_en"])
+
+    async def call_blu_trv(
+        self, idx: int, method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Call BLU TRV."""
+        call: tuple[str, dict[str, Any]] = (
+            "BluTRV.Call",
+            {"id": idx, "method": method, "params": params},
+        )
+        return (await self.call_rpc_multiple((call,), BLU_TRV_TIMEOUT))[0]
 
     async def call_rpc(
         self, method: str, params: dict[str, Any] | None = None

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "12.3.1"
+VERSION = "12.3.3"
 
 with open("requirements.txt", encoding="utf-8") as file:  # noqa: PTH123
     requirements = file.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "12.3.1"
+VERSION = "12.3.2"
 
 with open("requirements.txt", encoding="utf-8") as file:  # noqa: PTH123
     requirements = file.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "12.3.3"
+VERSION = "12.3.1"
 
 with open("requirements.txt", encoding="utf-8") as file:  # noqa: PTH123
     requirements = file.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "12.3.2"
+VERSION = "12.3.1"
 
 with open("requirements.txt", encoding="utf-8") as file:  # noqa: PTH123
     requirements = file.read().splitlines()


### PR DESCRIPTION
Fixes:

```
2025-01-25 12:06:27.045 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140619007080000] Unexpected exception
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-beta/venv/lib/python3.12/site-packages/aioshelly/rpc_device/wsrpc.py", line 504, in _rpc_calls
    response = await call.resolve
               ^^^^^^^^^^^^^^^^^^
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-beta/venv/lib/python3.12/site-packages/aioshelly/rpc_device/wsrpc.py", line 493, in _rpc_calls
    async with asyncio.timeout(timeout):
  File "/usr/local/lib/python3.12/asyncio/timeouts.py", line 115, in __aexit__
    raise TimeoutError from exc_val
TimeoutError

homeassistant.exceptions.HomeAssistantError: Call BLU TRV for Shelly BLU TRV [7744F8] external temperature connection error, method: Trv.SetExternalTemperature, id: 200, params: {'id': 0, 't_C': 22.9}, error: DeviceConnectionError()
```