### PR TITLE
Add `attrs` from dynamic component to the `config`

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -554,7 +554,10 @@ class RpcDevice:
             assert self._status is not None
 
         self._config.update(
-            {item["key"]: item["config"] for item in self._dynamic_components}
+            {
+                item["key"]: {**item["config"], **item["attrs"]}
+                for item in self._dynamic_components
+            }
         )
         self._status.update(
             {


### PR DESCRIPTION
This will allow us to map `attrs.role` to the device class for Powered by Shelly devices.