### PR TITLE
Remove XMOD model 

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -123,8 +123,6 @@ MODEL_I4_GEN3 = "S3SN-0024X"
 MODEL_OUT_PLUG_S_G3 = "S3PL-20112EU"
 MODEL_PM_MINI_G3 = "S3PM-001PCEU16"
 MODEL_PLUG_S_G3 = "S3PL-00112EU"
-MODEL_X_MOD1 = "S3MX-0A"
-MODEL_X_MOD_S3XT_0S = "S3XT-0S"
 # Gen4 RPC based models
 MODEL_1_G4 = "S4SW-001X16EU"
 MODEL_1_MINI_G4 = "S4SW-001X8EU"
@@ -938,13 +936,6 @@ DEVICES = {
         gen=GEN3,
         supported=True,
     ),
-    MODEL_X_MOD1: ShellyDevice(
-        model="S3MX-0A",
-        name="Shelly X MOD1",
-        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
-        gen=GEN3,
-        supported=True,
-    ),
     MODEL_1_G4: ShellyDevice(
         model=MODEL_1_G4,
         name="Shelly 1 Gen4",
@@ -1008,10 +999,6 @@ GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION = {
 BLU_TRV_IDENTIFIER = "blutrv"
 BLU_TRV_MODEL_ID = {8: "SBTR-001AEU"}
 BLU_TRV_MODEL_NAME = {"SBTR-001AEU": "Shelly BLU TRV"}
-
-# Models that doesn't support Bluetooth Proxy
-# either because they not support Bluetooth or because they don't support scripts
-MODELS_NOT_SUPPORTING_BT_PROXY = [MODEL_WALL_DISPLAY, MODEL_X_MOD_S3XT_0S]
 
 
 class UndefinedType(Enum):

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1009,8 +1009,8 @@ BLU_TRV_IDENTIFIER = "blutrv"
 BLU_TRV_MODEL_ID = {8: "SBTR-001AEU"}
 BLU_TRV_MODEL_NAME = {"SBTR-001AEU": "Shelly BLU TRV"}
 
-# Models that doesn't support BlueTooth Proxy
-# either because they not support BlueTooth or because they don't support scripts
+# Models that doesn't support Bluetooth Proxy
+# either because they not support Bluetooth or because they don't support scripts
 MODELS_NOT_SUPPORTING_BT_PROXY = [MODEL_WALL_DISPLAY, MODEL_X_MOD_S3XT_0S]
 
 

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -124,6 +124,7 @@ MODEL_OUT_PLUG_S_G3 = "S3PL-20112EU"
 MODEL_PM_MINI_G3 = "S3PM-001PCEU16"
 MODEL_PLUG_S_G3 = "S3PL-00112EU"
 MODEL_X_MOD1 = "S3MX-0A"
+MODEL_X_MOD_S3XT_0S = "S3XT-0S"
 # Gen4 RPC based models
 MODEL_1_G4 = "S4SW-001X16EU"
 MODEL_1_MINI_G4 = "S4SW-001X8EU"
@@ -1007,6 +1008,10 @@ GEN1_MODELS_SUPPORTING_LIGHT_TRANSITION = {
 BLU_TRV_IDENTIFIER = "blutrv"
 BLU_TRV_MODEL_ID = {8: "SBTR-001AEU"}
 BLU_TRV_MODEL_NAME = {"SBTR-001AEU": "Shelly BLU TRV"}
+
+# Models that doesn't support BlueTooth Proxy
+# either because they not support BlueTooth or because they don't support scripts
+MODELS_NOT_SUPPORTING_BT_PROXY = [MODEL_WALL_DISPLAY, MODEL_X_MOD_S3XT_0S]
 
 
 class UndefinedType(Enum):


### PR DESCRIPTION
For XMOD models product and name comes from JWT block and not from the standard "model" key