### PR TITLE
Update status instead of overwriting it when pooling

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -284,7 +284,7 @@ class RpcDevice:
         results = await self.call_rpc_multiple(calls, DEVICE_POLL_TIMEOUT)
         if (status := results[0]) is None:
             raise RpcCallError("empty response to Shelly.GetStatus")
-        if not self._status:
+        if self._status is None:
             raise NotInitialized
         self._status.update(status)
         if has_dynamic:

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -284,7 +284,9 @@ class RpcDevice:
         results = await self.call_rpc_multiple(calls, DEVICE_POLL_TIMEOUT)
         if (status := results[0]) is None:
             raise RpcCallError("empty response to Shelly.GetStatus")
-        self._status = status
+        if not self._status:
+            raise NotInitialized
+        self._status.update(status)
         if has_dynamic:
             if (dynamic := results[1]) is None:
                 raise RpcCallError("empty response to Shelly.GetComponents")


### PR DESCRIPTION
Fixes `KeyError` when `rssi` and `uptime` sensors are enable for BLU Gateway

```
2025-02-06 15:13:59.755 DEBUG (MainThread) [aioshelly.rpc_device.wsrpc] send(192.168.2.210:80): {'id': 12, 'method': 'Shelly.GetComponents', 'src': 'aios-140615453547488', 'params': {'dynamic_only': True}, 'dst': 'shellyblugwg3-34cdb078742c', 'auth': {'realm': 'shellyblugwg3-34cdb078742c', 'username': 'admin', 'nonce': 1738849439, 'cnonce': 1738851239, 'response': '6849f9f88eef4ebb4c22c0e4d1948a1c371432d137688b75232c1097ec614a22', 'algorithm': 'SHA-256'}}
2025-02-06 15:13:59.760 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.13/site-packages/aioshelly/rpc_device/wsrpc.py", line 371, in _rx_msgs
    self.handle_frame(RPCSource.CLIENT, frame)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.13/site-packages/aioshelly/rpc_device/wsrpc.py", line 315, in handle_frame
    self._on_notification(source, method, params)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.13/site-packages/aioshelly/rpc_device/device.py", line 171, in _on_notification
    self._update_listener(self, update_type)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/coordinator.py", line 754, in _async_handle_update
    self.async_set_updated_data(None)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 515, in async_set_updated_data
    self.async_update_listeners()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 178, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 391, in _update_callback
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 1085, in __async_calculate_state
    state = self._stringify_state(available)
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 1029, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/binary_sensor/__init__.py", line 200, in state
    if (is_on := self.is_on) is None:
                 ^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/binary_sensor.py", line 71, in is_on
    return bool(self.attribute_value)
                ^^^^^^^^^^^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 564, in attribute_value
    self.status.get(self.entity_description.sub_key), self._last_value
    ^^^^^^^^^^^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/entity.py", line 381, in status
    return cast(dict, self.coordinator.device.status[self.key])
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'blutrv:200'
```