### PR TITLE
Add BLE support check

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -116,7 +116,7 @@ async def async_ble_supported(device: RpcDevice) -> bool:
     Try to read a script to check if the device supports scripts,
     if it supports scripts, it should return the script
     or a specific error code if the script does not exist.
-    {"code":-105,"message":"Argument 'id', value -1 not found!"}
+    {"code":-105,"message":"Argument 'id', value 1 not found!"}
 
     Errors by devices that do not support scripts:
 

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -83,7 +83,7 @@ def create_scanner(
         name,
         HaBluetoothConnector(
             # no active connections to shelly yet
-            client=None,
+            client=None,  # type: ignore[arg-type]
             source=source,
             can_connect=lambda: False,
         ),

--- a/aioshelly/ble/const.py
+++ b/aioshelly/ble/const.py
@@ -8,6 +8,10 @@ BLE_SCRIPT_NAME = "aioshelly_ble_integration"
 
 BLE_SCAN_RESULT_VERSION = 2
 
+RPC_CALL_ERR_METHOD_NOT_FOUND = -114
+RPC_CALL_ERR_INVALID_ARG = -105
+RPC_CALL_ERR_NO_HANDLER = 404
+
 VAR_EVENT_TYPE = "%event_type%"
 VAR_ACTIVE = "%active%"
 VAR_VERSION = "%version%"

--- a/tests/rpc_device/test_ble.py
+++ b/tests/rpc_device/test_ble.py
@@ -1,0 +1,55 @@
+"""Tests for BLE module."""
+
+from typing import Any
+
+import pytest
+
+from aioshelly.ble import async_ble_supported
+from aioshelly.exceptions import RpcCallError
+from aioshelly.rpc_device.device import RpcDevice
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "ble_supported"),
+    [
+        (RpcCallError(-105, "Argument 'id', value 1 not found!"), True),
+        (RpcCallError(-114, "Method Script.GetCode failed: Method not found!"), False),
+        (RpcCallError(404, "No handler for Script.GetCode"), False),
+        (
+            [
+                {
+                    "id": 5,
+                    "src": "shellyplus2pm-a8032ab720ac",
+                    "dst": "aios-2293750469632",
+                    "result": {"data": "script"},
+                }
+            ],
+            True,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_ble_supported(
+    rpc_device: RpcDevice,
+    side_effect: Exception | dict[str, Any],
+    ble_supported: bool,
+) -> None:
+    """Test async_ble_supported method."""
+    rpc_device.call_rpc_multiple.side_effect = [side_effect]
+
+    result = await async_ble_supported(rpc_device)
+
+    assert result == ble_supported
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][0] == "Script.GetCode"
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][1] == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_ble_supported_raises_unkown_errors(rpc_device: RpcDevice) -> None:
+    """Test async_ble_supported raises for unknown errors."""
+    message = "Missing required argument 'id'!"
+    rpc_device.call_rpc_multiple.side_effect = [RpcCallError(-103, message)]
+
+    with pytest.raises(RpcCallError, match=message):
+        await async_ble_supported(rpc_device)

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import ClientSession
 
+from aioshelly.ble import async_ble_supported
 from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions, get_info
 from aioshelly.const import (
@@ -187,6 +188,15 @@ async def update_outbound_ws(
         device: RpcDevice = await create_device(aiohttp_session, options, init, 2)
         print(f"Updating outbound weboskcet URL to {ws_url}")
         print(f"Restart required: {await device.update_outbound_websocket(ws_url)}")
+
+
+async def check_if_ble_supported(options: ConnectionOptions, gen: int | None) -> None:
+    """Check if BLE is supported."""
+    async with ClientSession() as aiohttp_session:
+        device: RpcDevice = await create_device(aiohttp_session, options, gen)
+        await device.initialize()
+        print(f"BLE supported: {await async_ble_supported(device)}")
+        await device.shutdown()
 
 
 async def wait_for_keyboard_interrupt() -> None:

--- a/tools/example.py
+++ b/tools/example.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from aiohttp import ClientSession
 from common import (
+    check_if_ble_supported,
     close_connections,
     coap_context,
     connect_and_print_device,
@@ -158,6 +159,12 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         default=None,
         help="Listen ip address for incoming CoAP packets",
     )
+    parser.add_argument(
+        "--ble-supported",
+        "-bs",
+        action="store_true",
+        help="Check if BLE is supported by the device",
+    )
 
     arguments = parser.parse_args()
 
@@ -212,6 +219,8 @@ async def main() -> None:
         )
         if args.update_ws:
             await update_outbound_ws(options, args.init, args.update_ws)
+        elif args.ble_supported:
+            await check_if_ble_supported(options, gen)
         else:
             await test_single(options, args.init, gen)
     else:


### PR DESCRIPTION
Detect if device supports BLE by trying to read a script from the device instead of hardcoded models list and catch known errors.
The method checks for BLE support although for now it is only breaks if scripts are not supported so we can expand it in the future if another device has a script but does not support BLE scanning.

Updated the example to be able to test the new method on real devices.
Tested on:
- Shelly Wall Display --> return `False`
- Shelly Wall Display X2 --> return `False`
- LinkedGo Starlight Thermostat ST1820 --> return `False`
- Shelly Plus 2PM with existing script --> return `True`
- Shelly Pro 2 without script --> return `True`

