### PR TITLE
Do not raise `WrongShellyGen` in `RpcDevice`

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -37,7 +37,6 @@ from ..exceptions import (
     NotInitialized,
     RpcCallError,
     ShellyError,
-    WrongShellyGen,
 )
 from .models import (
     ShellyBLEConfig,
@@ -418,9 +417,6 @@ class RpcDevice:
     @property
     def requires_auth(self) -> bool:
         """Device check for authentication."""
-        if "auth_en" not in self.shelly:
-            raise WrongShellyGen
-
         return bool(self.shelly["auth_en"])
 
     async def call_rpc(


### PR DESCRIPTION
We still need to raise a `WrongShellyGen` exception for Gen1 devices since the `/shelly` endpoint is available for all generations.

![obraz](https://github.com/user-attachments/assets/e0de1373-e8a5-4d8d-8c0e-c0539ecaae1c)
