### PR TITLE
Fix missing semicolon in BLE Script

### DIFF
--- a/aioshelly/ble/const.py
+++ b/aioshelly/ble/const.py
@@ -47,7 +47,7 @@ function timerCallback() {
 
 function bleCallback(event, res) {
   if (event !== BLE.Scanner.SCAN_RESULT) {
-    return
+    return;
   }
 
   if (queue.length > maxQueue) {


### PR DESCRIPTION
This single return statement with the missing semicolon seems inconsistent with the rest of the script and Shelly's scripting language isn't exactly JavaScript. Some older version thereof even said semicolons are mandatory. This PR is therefore adding the missing semicolon.