### PR TITLE
Add support for getting the bluetooth MAC form the primary MAC

### DIFF
--- a/aioshelly/rpc_device/__init__.py
+++ b/aioshelly/rpc_device/__init__.py
@@ -1,6 +1,7 @@
 """Shelly Gen2 RPC based device."""
 
 from .device import RpcDevice, RpcUpdateType
+from .utils import bluetooth_mac_from_primary_mac
 from .wsrpc import WsServer
 
-__all__ = ["RpcDevice", "RpcUpdateType", "WsServer"]
+__all__ = ["RpcDevice", "RpcUpdateType", "WsServer", "bluetooth_mac_from_primary_mac"]

--- a/aioshelly/rpc_device/utils.py
+++ b/aioshelly/rpc_device/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 def bluetooth_mac_from_primary_mac(primary_mac: str) -> str:
     """Get Bluetooth MAC from primary MAC.
 
-    MAC address must be in format "0-F{16}"
+    MAC address must be in format "[0-F]{16}"
 
     :param primary_mac: Primary MAC address
     :return: Bluetooth MAC address

--- a/aioshelly/rpc_device/utils.py
+++ b/aioshelly/rpc_device/utils.py
@@ -1,0 +1,17 @@
+"""Utilities for RPC devices."""
+
+from __future__ import annotations
+
+# The Bluetooth MAC address is the primary MAC address plus 2.
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#mac-address
+
+
+def bluetooth_mac_from_primary_mac(primary_mac: str) -> str:
+    """Get Bluetooth MAC from primary MAC.
+
+    MAC address must be in format "0-F{16}"
+
+    :param primary_mac: Primary MAC address
+    :return: Bluetooth MAC address
+    """
+    return f"{(int(primary_mac, 16) + 2):012X}"

--- a/tests/rpc_device/test_init.py
+++ b/tests/rpc_device/test_init.py
@@ -1,0 +1,9 @@
+from aioshelly import rpc_device
+
+
+def test_exports() -> None:
+    """Test objects are available at top level of rpc_device."""
+    assert hasattr(rpc_device, "bluetooth_mac_from_primary_mac")
+    assert hasattr(rpc_device, "RpcDevice")
+    assert hasattr(rpc_device, "RpcUpdateType")
+    assert hasattr(rpc_device, "WsServer")

--- a/tests/rpc_device/test_utils.py
+++ b/tests/rpc_device/test_utils.py
@@ -1,0 +1,9 @@
+from aioshelly.rpc_device.utils import bluetooth_mac_from_primary_mac
+
+
+def test_bluetooth_mac_from_primary_mac() -> None:
+    """Test bluetooth_mac_from_primary_mac."""
+    assert bluetooth_mac_from_primary_mac("0A1B2C3D4E5F") == "0A1B2C3D4E61"
+    assert bluetooth_mac_from_primary_mac("0A1B2C3D4EA0") == "0A1B2C3D4EA2"
+    assert bluetooth_mac_from_primary_mac("0A1B2C3D4EF0") == "0A1B2C3D4EF2"
+    assert bluetooth_mac_from_primary_mac("0A1B2C3D4EC9") == "0A1B2C3D4ECB"


### PR DESCRIPTION
Add `bluetooth_mac_from_primary_mac` which accepts the primary MAC and returns the Bluetooth MAC

The MAC must be in the format `[0-F]{16}`