### PR TITLE
Add support for passing the BluetoothScanningMode to the scanner

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from habluetooth import HaBluetoothConnector
+from habluetooth import BluetoothScanningMode, HaBluetoothConnector
 
 from ..exceptions import RpcCallError
 from ..rpc_device import RpcDevice
@@ -73,6 +73,8 @@ async def async_start_scanner(
 def create_scanner(
     source: str,
     name: str,
+    requested_mode: BluetoothScanningMode | None = None,
+    current_mode: BluetoothScanningMode | None = None,
 ) -> ShellyBLEScanner:
     """Create scanner."""
     return ShellyBLEScanner(
@@ -85,6 +87,8 @@ def create_scanner(
             can_connect=lambda: False,
         ),
         False,
+        requested_mode=requested_mode,
+        current_mode=current_mode,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bluetooth-data-tools>=1.19.0
 aiohttp>=3.11.1
-habluetooth>=2.1.0
+habluetooth>=3.22.0
 yarl
 orjson>=3.8.1

--- a/tests/ble/__init__.py
+++ b/tests/ble/__init__.py
@@ -1,0 +1,1 @@
+"""Shelly BLE tests."""

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -1,0 +1,31 @@
+"""Tests for the BLE initialization."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import habluetooth
+import pytest
+import pytest_asyncio
+from habluetooth import BluetoothScanningMode
+
+from aioshelly.ble import create_scanner
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def ha_manager() -> MagicMock:
+    """Mock ha manager."""
+    await habluetooth.BluetoothManager().async_setup()
+
+
+@pytest.mark.asyncio
+async def test_create_scanner() -> None:
+    """Test create scanner."""
+    scanner = create_scanner(
+        "AA:BB:CC:DD:EE:FF",
+        "shelly",
+        BluetoothScanningMode.ACTIVE,
+        BluetoothScanningMode.ACTIVE,
+    )
+    assert scanner.requested_mode == BluetoothScanningMode.ACTIVE
+    assert scanner.current_mode == BluetoothScanningMode.ACTIVE

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -37,3 +37,11 @@ async def test_create_scanner(
     )
     assert scanner.requested_mode == requested_mode
     assert scanner.current_mode == current_mode
+
+
+@pytest.mark.asyncio
+async def test_create_scanner_back_compat() -> None:
+    """Test create scanner works without modes."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    assert scanner.requested_mode is None
+    assert scanner.current_mode is None

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -19,13 +19,21 @@ async def ha_manager() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_create_scanner() -> None:
+@pytest.mark.parametrize(
+    ("requested_mode", "current_mode"),
+    [
+        (BluetoothScanningMode.ACTIVE, BluetoothScanningMode.ACTIVE),
+        (BluetoothScanningMode.PASSIVE, BluetoothScanningMode.PASSIVE),
+        (BluetoothScanningMode.ACTIVE, BluetoothScanningMode.PASSIVE),
+        (BluetoothScanningMode.PASSIVE, BluetoothScanningMode.ACTIVE),
+    ],
+)
+async def test_create_scanner(
+    requested_mode: BluetoothScanningMode, current_mode: BluetoothScanningMode
+) -> None:
     """Test create scanner."""
     scanner = create_scanner(
-        "AA:BB:CC:DD:EE:FF",
-        "shelly",
-        BluetoothScanningMode.ACTIVE,
-        BluetoothScanningMode.ACTIVE,
+        "AA:BB:CC:DD:EE:FF", "shelly", requested_mode, current_mode
     )
-    assert scanner.requested_mode == BluetoothScanningMode.ACTIVE
-    assert scanner.current_mode == BluetoothScanningMode.ACTIVE
+    assert scanner.requested_mode == requested_mode
+    assert scanner.current_mode == current_mode


### PR DESCRIPTION
We want `habluetooth` to be able to make better decisions about routing advertisement data, however we currently don't know if a shelly scanner is in passive or active mode so this is not possible.