### PR TITLE
Remove 'Version' prefix from release-drafter name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: "Version $RESOLVED_VERSION"
+name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 
 categories:


### PR DESCRIPTION
Modify the `name-template` to remove the "Version" prefix, to match our existing release names.
