### PR TITLE
Update script support check to use invalid script ID for validation

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -616,10 +616,9 @@ class RpcDevice:
     async def supports_scripts(self) -> bool:
         """Check if the device supports scripts.
 
-        Try to read a script to check if the device supports scripts,
-        if it supports scripts, it should return the script
-        or a specific error code if the script does not exist.
-        {"code":-105,"message":"Argument 'id', value 1 not found!"}
+        Try to read an invalid script ID to check if the device supports scripts,
+        if it supports scripts, it should return a specific error code:
+        {"code":-105,"message":"Argument 'id', value -1 not found!"}
 
         Errors by devices that do not support scripts:
 
@@ -630,7 +629,7 @@ class RpcDevice:
         {"code":404,"message":"No handler for Script.GetCode"}
         """
         try:
-            await self.script_getcode(1)
+            await self.script_getcode(-1)
         except RpcCallError as err:
             # The device supports scripts, but the script does not exist
             if err.code == RPC_CALL_ERR_INVALID_ARG:
@@ -643,5 +642,6 @@ class RpcDevice:
                 return False
             raise
 
-        # The device returned a script, it supports scripts
-        return True
+        # Tried to fetch an invalid script ID, but no error was raised
+        # This means the device does not supports scripts
+        return False

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -789,20 +789,10 @@ async def test_incorrect_shutdown(
 @pytest.mark.parametrize(
     ("side_effect", "supports_scripts"),
     [
-        (RpcCallError(-105, "Argument 'id', value 1 not found!"), True),
+        (RpcCallError(-105, "Argument 'id', value -1 not found!"), True),
         (RpcCallError(-114, "Method Script.GetCode failed: Method not found!"), False),
         (RpcCallError(404, "No handler for Script.GetCode"), False),
-        (
-            [
-                {
-                    "id": 5,
-                    "src": "shellyplus2pm-a8032ab720ac",
-                    "dst": "aios-2293750469632",
-                    "result": {"data": "script"},
-                }
-            ],
-            True,
-        ),
+        (AsyncMock(return_value=None), False),
     ],
 )
 @pytest.mark.asyncio
@@ -819,7 +809,7 @@ async def test_supports_scripts(
     assert result == supports_scripts
     assert rpc_device.call_rpc_multiple.call_count == 1
     assert rpc_device.call_rpc_multiple.call_args[0][0][0][0] == "Script.GetCode"
-    assert rpc_device.call_rpc_multiple.call_args[0][0][0][1] == {"id": 1}
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][1] == {"id": -1}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/issues/142190#issuecomment-2779662995, reading a large script fails, so instead read an invalid script.

Tested with:
- Shelly Pro 2PM
- Shelly Wall Display X2
- LinkedGo ST1820
