### PR TITLE
Add initial tests for block_device module

### DIFF
--- a/tests/block_device/__init__.py
+++ b/tests/block_device/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Block device."""

--- a/tests/block_device/conftest.py
+++ b/tests/block_device/conftest.py
@@ -1,0 +1,13 @@
+"""Tests for Block device."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest_asyncio
+from aiohttp.client import ClientSession
+
+
+@pytest_asyncio.fixture
+async def client_session() -> AsyncGenerator[ClientSession, None]:
+    """Fixture for a ClientSession."""
+    return MagicMock(spec=ClientSession)

--- a/tests/block_device/test_device.py
+++ b/tests/block_device/test_device.py
@@ -1,0 +1,38 @@
+"""Tests for block_device.device module."""
+
+import asyncio
+import socket
+from unittest.mock import Mock
+
+import pytest
+from aiohttp.client import ClientSession
+
+from aioshelly.block_device import COAP, BlockDevice
+from aioshelly.common import ConnectionOptions
+
+
+@pytest.mark.asyncio
+async def test_incorrect_shutdown(
+    client_session: ClientSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test multiple shutdown calls at incorrect order.
+
+    https://github.com/home-assistant-libs/aioshelly/pull/535
+    """
+    coap_context = COAP()
+    coap_context.sock = Mock(spec=socket.socket)
+    coap_context.transport = Mock(spec=asyncio.DatagramTransport)
+    options = ConnectionOptions("10.10.10.10", device_mac="AABBCCDDEEFF")
+
+    block_device1 = await BlockDevice.create(client_session, coap_context, options)
+    block_device2 = await BlockDevice.create(client_session, coap_context, options)
+
+    # shutdown for device2 remove subscription for device1 from ws_context
+    await block_device2.shutdown()
+
+    assert "error during shutdown: KeyError('DDEEFF')" not in caplog.text
+
+    await block_device1.shutdown()
+
+    assert "error during shutdown: KeyError('DDEEFF')" in caplog.text

--- a/tests/block_device/test_init.py
+++ b/tests/block_device/test_init.py
@@ -1,0 +1,10 @@
+from aioshelly import block_device
+
+
+def test_exports() -> None:
+    """Test objects are available at top level of block_device."""
+    assert hasattr(block_device, "BLOCK_VALUE_UNIT")
+    assert hasattr(block_device, "COAP")
+    assert hasattr(block_device, "Block")
+    assert hasattr(block_device, "BlockDevice")
+    assert hasattr(block_device, "BlockUpdateType")


### PR DESCRIPTION
Create initial tests for block_device module, this mainly so that code is imported, only two tests added but now we can expand coverage by adding more tests.
