### PR TITLE
Bump bluetooth-data-tools to 1.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.1",
-  "bluetooth-data-tools>=1.19.0",
+  "bluetooth-data-tools>=1.28.0",
   "habluetooth>=3.42.0",
   "orjson>=3.8.1",
   "yarl",


### PR DESCRIPTION
This version is already required but since we pin it in HA and we don't use the ble code directly outside of HA it likely hasn't been a problem

changelog: https://github.com/Bluetooth-Devices/bluetooth-data-tools/compare/v1.19.0...v1.28.0