### PR TITLE
Add model IDs for 1L Gen3 and 2L Gen3

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -110,9 +110,11 @@ MODEL_WALL_DISPLAY = "SAWD-0A1XX10EU1"
 MODEL_WALL_DISPLAY_X2 = "SAWD-2A1XX10EU1"
 # Gen3 RPC based models
 MODEL_1_G3 = "S3SW-001X16EU"
+MODEL_1L_G3 = "S3SW-0A1X1EUL"
 MODEL_1_MINI_G3 = "S3SW-001X8EU"
 MODEL_1PM_G3 = "S3SW-001P16EU"
 MODEL_1PM_MINI_G3 = "S3SW-001P8EU"
+MODEL_2L_G3 = "S3SW-0A2X4EUL"
 MODEL_2PM_G3 = "S3SW-002P16EU"
 MODEL_3EM_63_G3 = "S3EM-003CXCEU63"
 MODEL_AZ_PLUG = "S3PL-10112EU"
@@ -856,6 +858,13 @@ DEVICES = {
         gen=GEN3,
         supported=True,
     ),
+    MODEL_1L_G3: ShellyDevice(
+        model=MODEL_1L_G3,
+        name="Shelly 1L Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
     MODEL_1_MINI_G3: ShellyDevice(
         model=MODEL_1_MINI_G3,
         name="Shelly 1 Mini Gen3",
@@ -873,6 +882,13 @@ DEVICES = {
     MODEL_1PM_MINI_G3: ShellyDevice(
         model=MODEL_1PM_MINI_G3,
         name="Shelly 1PM Mini Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
+    MODEL_2L_G3: ShellyDevice(
+        model=MODEL_2L_G3,
+        name="Shelly 2L Gen3",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
         supported=True,


### PR DESCRIPTION
1L Gen3
```json
{
  "name": "null",
  "id": "shelly1lg3-xxxxxxxxxxxx",
  "mac": "XXXXXXXXXXXX",
  "slot": 1,
  "model": "S3SW-0A1X1EUL",
  "gen": 3,
  "fw_id": "20250319-150640/1.6.99-xlg3prod0-g1c18aaa",
  "ver": "1.6.99-xlg3prod0",
  "app": "S1LG3",
  "auth_en": false,
  "auth_domain": null
}
```

2L Gen3
```json
{
  "name": null,
  "id": "shelly2lg3-xxxxxxxxxxxx",
  "mac": "XXXXXXXXXXXX",
  "slot": 0,
  "model": "S3SW-0A2X4EUL",
  "gen": 3,
  "fw_id": "20250508-110809/1.6.1-g8dbd358",
  "ver": "1.6.1",
  "app": "S2LG3",
  "auth_en": false,
  "auth_domain": null,
  "matter": false
}
```