### PR TITLE
Improve Block device initialization 

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1067,6 +1067,9 @@ UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
+# Number of retries for cit/s requests
+CIT_S_RETRIES = 3
+
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10.0
 


### PR DESCRIPTION
Refactor Block device (Gen1) initialization process by changing UDP based transactions:
- For `cit/d` use HTTP instead of UDP, this is based on TCP now and has internal retry logic, this is the most failed stage when looking at logs from users since this packet is large.
- For `cit/s` HTTP is not available so perform 3 retries before we fail, this is based on `DEVICE_IO_TIMEOUT` so should not increase the device init time upon failures.
