### PR TITLE
Fix Block device cit/d for older firmware versions

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -148,6 +148,10 @@ GEN4 = 4
 # Firmware 1.9.0 release date
 GEN1_MIN_FIRMWARE_DATE = 20201124
 
+# Firmware 1.10.0 release date
+# Introduced cit/d via HTTP request
+GEN1_HTTP_CIT_D_MIN_FIRMWARE_DATE = 20210302
+
 # Firmware 1.11.0 release date (introduction of light transition)
 # Due to date fluctuation for different models,
 # GEN1_LIGHT_TRANSITION_MIN_FIRMWARE_DATE was used.
@@ -1067,8 +1071,8 @@ UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 
 MODEL_NAMES = {data.model: data.name for data in DEVICES.values()}
 
-# Number of retries for cit/s requests
-CIT_S_RETRIES = 3
+# Number of retries for cit requests
+CIT_RETRIES = 3
 
 # Timeout used for Device IO
 DEVICE_IO_TIMEOUT = 10.0


### PR DESCRIPTION
**Shelly Gen1 changelog:**
<img width="725" height="109" alt="image" src="https://github.com/user-attachments/assets/4e7b1d90-c7fc-46a2-a3da-b299ddd03654" />

Requesting `cit/d` for Block devices introduced at firmware v1.10 (released at 02.03.2021), currently we still support devices with firmware v1.9:
https://github.com/home-assistant-libs/aioshelly/blob/8df2cdea1d0e947d986da43e46418fe433c9f714/aioshelly/const.py#L148-L149
Mainly due to some of them not having a newer firmware, such as Shelly Plug 1 - latest firmware is v.1.9.4, related to https://github.com/home-assistant/core/issues/148607

This PR checks that the firmware at least at v1.10 for using HTTP `cit/d` requests and fallback to `CoAP` `cit/d` for older devices.

Tested with:
- Shelly Plug 1 with firmware v1.9.4 (latest, fallback)
- Shelly 1 with firmware v1.9.4 (fallback)
- Shelly 1 with firmware v1.10.1 (http)
- Shelly 1 with firmware v1.14.0 (latest, http)
- Shelly 2.5 with firmware v1.14.0 (latest, http)