### PR TITLE
Add button_trigger method to RpcDevice

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -334,6 +334,14 @@ class RpcDevice:
         }
         await self.call_rpc("BluTRV.Call", params=params, timeout=BLU_TRV_TIMEOUT)
 
+    async def button_trigger(self, id_: int, event: str) -> None:
+        """Trigger the button component."""
+        params = {
+            "id": id_,
+            "event": event,
+        }
+        await self.call_rpc("Button.Trigger", params=params)
+
     async def enum_set(self, id_: int, value: str) -> None:
         """Set the value for the enum component."""
         params = {

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -1024,6 +1024,22 @@ async def test_number_set(
 
 
 @pytest.mark.asyncio
+async def test_button_trigger(
+    rpc_device: RpcDevice,
+) -> None:
+    """Test RpcDevice button_trigger() method."""
+    await rpc_device.button_trigger(12, "single_push")
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    call_args_list = rpc_device.call_rpc_multiple.call_args_list
+    assert call_args_list[0][0][0][0][0] == "Button.Trigger"
+    assert call_args_list[0][0][0][0][1] == {
+        "id": 12,
+        "event": "single_push",
+    }
+
+
+@pytest.mark.asyncio
 async def test_enum_set(
     rpc_device: RpcDevice,
 ) -> None:


### PR DESCRIPTION
Add button_trigger method to RpcDevice which is required for supporting the button virtual component:
https://shelly-api-docs.shelly.cloud/gen2/DynamicComponents/Virtual/Button#buttontrigger

This is already in use by FrankEver Smart water valve - https://www.shelly.com/products/frankever-smart-water-valve-fk-v02t

<img width="662" height="170" alt="image" src="https://github.com/user-attachments/assets/0e65d621-1929-45fa-9653-659f8682ea0d" />

Home Assistant:
<img width="321" height="204" alt="image" src="https://github.com/user-attachments/assets/8d5deb9d-ec53-49dc-8629-e869f84d711e" />

```json
   {
      "key": "button:200",
      "status": {

      },
      "config": {
        "id": 200,
        "name": "Close",
        "meta": {
          "ui": {
            "view": "button"
          }
        },
        "owner": "service:0",
        "access": "crw"
      },
      "attrs": {
        "owner": "service:0",
        "role": "close"
      }
    },
    {
      "key": "button:201",
      "status": {

      },
      "config": {
        "id": 201,
        "name": "Open",
        "meta": {
          "ui": {
            "view": "button"
          }
        },
        "owner": "service:0",
        "access": "crw"
      },
      "attrs": {
        "owner": "service:0",
        "role": "open"
      }
    },
```

