### PR TITLE
Add model info for Duo Bulb Gen3

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -124,6 +124,7 @@ MODEL_BLU_GATEWAY_G3 = "S3GW-1DBT001"
 MODEL_DALI_DIMMER_G3 = "S3DM-0A1WW"
 MODEL_DIMMER_10V_G3 = "S3DM-0010WW"
 MODEL_DIMMER_G3 = "S3DM-0A101WWL"
+MODEL_DUO_BULB_G3 = "S3BL-D010009AEU"
 MODEL_EM_G3 = "S3EM-002CXCEU"
 MODEL_HT_G3 = "S3SN-0U12A"
 MODEL_I4_G3 = "S3SN-0024X"
@@ -955,6 +956,13 @@ DEVICES = {
     MODEL_DIMMER_G3: ShellyDevice(
         model=MODEL_DIMMER_G3,
         name="Shelly Dimmer Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
+    MODEL_DUO_BULB_G3: ShellyDevice(
+        model=MODEL_DUO_BULB_G3,
+        name="Shelly Duo Bulb Gen3",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
         supported=True,


### PR DESCRIPTION
```json
{
    "name": "Shelly Duo Bulb Gen3 [DDEEFF]",
    "id": "shellyduobulbg3-aabbccddeeff",
    "mac": "AABBCCDDEEFF",
    "slot": 0,
    "model": "S3BL-D010009AEU",
    "gen": 3,
    "fw_id": "20250909-133941/i4g4zb_certification_iteration_0-99-g1d070a496-main",
    "ver": "1.8.99",
    "app": "DuoBulbG3",
    "auth_en": true,
    "auth_domain": "shellyduobulbg3-AABBCCDDEEFF"
}
```