### PR TITLE
Add model info for Multicolor Bulb Gen3

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -128,6 +128,7 @@ MODEL_DUO_BULB_G3 = "S3BL-D010009AEU"
 MODEL_EM_G3 = "S3EM-002CXCEU"
 MODEL_HT_G3 = "S3SN-0U12A"
 MODEL_I4_G3 = "S3SN-0024X"
+MODEL_MULTICOLOR_BULB_G3 = "S3BL-C010007AEU"
 MODEL_OUT_PLUG_S_G3 = "S3PL-20112EU"
 MODEL_PLUG_S_G3 = "S3PL-00112EU"
 MODEL_PM_MINI_G3 = "S3PM-001PCEU16"
@@ -984,6 +985,13 @@ DEVICES = {
     MODEL_I4_G3: ShellyDevice(
         model=MODEL_I4_G3,
         name="Shelly I4 Gen3",
+        min_fw_date=GEN3_MIN_FIRMWARE_DATE,
+        gen=GEN3,
+        supported=True,
+    ),
+    MODEL_MULTICOLOR_BULB_G3: ShellyDevice(
+        model=MODEL_MULTICOLOR_BULB_G3,
+        name="Shelly Multicolor Bulb Gen3",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
         supported=True,


### PR DESCRIPTION
```json
{
    "name": "Shelly Multicolor Bulb Gen3 [DDEEFF]",
    "id": "shellycolorblbg3-AABBCCDDEEFF",
    "mac": "AABBCCDDEEFF",
    "slot": 0,
    "model": "S3BL-C010007AEU",
    "gen": 3,
    "fw_id": "20250909-134125/i4g4zb_certification_iteration_0-99-g1d070a496-main",
    "ver": "1.8.99",
    "app": "RGBCCTBulbG3",
    "auth_en": false,
    "auth_domain": null
}
```