### PR TITLE
Add `boolean_set` method to `RpcDevice`

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -334,6 +334,14 @@ class RpcDevice:
         }
         await self.call_rpc("BluTRV.Call", params=params, timeout=BLU_TRV_TIMEOUT)
 
+    async def boolean_set(self, id_: int, value: bool) -> None:
+        """Set the value for the boolean component."""
+        params = {
+            "id": id_,
+            "value": value,
+        }
+        await self.call_rpc("Boolean.Set", params=params)
+
     async def button_trigger(self, id_: int, event: str) -> None:
         """Trigger the button component."""
         params = {

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -1029,6 +1029,22 @@ async def test_number_set(
 
 
 @pytest.mark.asyncio
+async def test_boolean_set(
+    rpc_device: RpcDevice,
+) -> None:
+    """Test RpcDevice button_trigger() method."""
+    await rpc_device.boolean_set(12, True)
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    call_args_list = rpc_device.call_rpc_multiple.call_args_list
+    assert call_args_list[0][0][0][0][0] == "Boolean.Set"
+    assert call_args_list[0][0][0][0][1] == {
+        "id": 12,
+        "value": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_button_trigger(
     rpc_device: RpcDevice,
 ) -> None:


### PR DESCRIPTION
Add `boolean_set` method to `RpcDevice` for replacing direct use of lower level method `call_rpc` upstream
