### PR TITLE
fix test warning

### DIFF
--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -402,11 +402,11 @@ async def test_device_already_initialized(
 @pytest.mark.parametrize(
     ("exc", "result_exc", "result_str"),
     [
-        (InvalidAuthError, InvalidAuthError, ""),
+        (InvalidAuthError, InvalidAuthError, None),
         (RpcCallError(404, "test error"), DeviceConnectionError, "test error"),
-        (ClientError, DeviceConnectionError, ""),
-        (DeviceConnectionError, DeviceConnectionError, ""),
-        (OSError, DeviceConnectionError, ""),
+        (ClientError, DeviceConnectionError, None),
+        (DeviceConnectionError, DeviceConnectionError, None),
+        (OSError, DeviceConnectionError, None),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
```
========================================================= warnings summary ==========================================================
tests/rpc_device/test_device.py::test_device_exception_on_init[InvalidAuthError-InvalidAuthError-]
tests/rpc_device/test_device.py::test_device_exception_on_init[ClientError-DeviceConnectionError-]
tests/rpc_device/test_device.py::test_device_exception_on_init[DeviceConnectionError-DeviceConnectionError-]
tests/rpc_device/test_device.py::test_device_exception_on_init[OSError-DeviceConnectionError-]
  /home/vscode/.local/lib/python3.11/site-packages/_pytest/raises.py:624: PytestWarning: matching against an empty string will *always* pass. If you want to check for an empty message you need to pass '^$'. If you don't want to match you should pass `None` or leave out the parameter.
    super().__init__(match=match, check=check)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```