### PR TITLE
Add model ID for Shelly Cury

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -139,6 +139,7 @@ MODEL_1_MINI_G4 = "S4SW-001X8EU"
 MODEL_1PM_G4 = "S4SW-001P16EU"
 MODEL_1PM_MINI_G4 = "S4SW-001P8EU"
 MODEL_2PM_G4 = "S4SW-002P16EU"
+MODEL_CURY_G4 = "S4PB-00CU000002"
 MODEL_DIMMER_G4 = "S4DM-0A101WWL"
 MODEL_FLOOD_G4 = "S4SN-0071A"
 MODEL_I4_G4 = "S4SN-0A24X"
@@ -1058,6 +1059,13 @@ DEVICES = {
     MODEL_2PM_G4: ShellyDevice(
         model=MODEL_2PM_G4,
         name="Shelly 2PM Gen4",
+        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
+        gen=GEN4,
+        supported=True,
+    ),
+    MODEL_CURY_G4: ShellyDevice(
+        model=MODEL_CURY_G4,
+        name="Shelly Cury",
         min_fw_date=GEN4_MIN_FIRMWARE_DATE,
         gen=GEN4,
         supported=True,


### PR DESCRIPTION
```json
{
    "name": null,
    "id": "cury-aabbccddeeff",
    "mac": "AABBCCDDEEFF",
    "slot": 1,
    "model": "S4PB-00CU000002",
    "gen": 4,
    "fw_id": "20250919-130019/ga58ebcd",
    "ver": "1.8.99-dev139709",
    "app": "Cury",
    "auth_en": false,
    "auth_domain": null
}
```