### PR TITLE
Update pytest-asyncio to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ lint = [
 dev = [
   "aioresponses==0.7.8",
   "pre-commit==4.4.0",
-  "pytest-asyncio==1.2.0",
+  "pytest-asyncio==1.3.0",
   "pytest-cov==7.0.0",
   "pytest==8.4.2",
   "requests",


### PR DESCRIPTION
Fix https://github.com/home-assistant-libs/aioshelly/actions/runs/19223128716/job/54944724193?pr=981#step:5:32

Release notes: https://github.com/pytest-dev/pytest-asyncio/releases/tag/v1.3.0
diff: https://github.com/pytest-dev/pytest-asyncio/compare/v1.2.0...v1.3.0
