### PR TITLE
Fix MAC address byte order in BLE manufacturer data parsing

### DIFF
--- a/aioshelly/ble/manufacturer_data.py
+++ b/aioshelly/ble/manufacturer_data.py
@@ -58,12 +58,12 @@ def parse_shelly_manufacturer_data(
             offset += 2
 
         elif block_type == BLOCK_TYPE_MAC:
-            # 6 bytes MAC address
+            # 6 bytes MAC address (stored in reverse order)
             if offset + 6 > len(data):
                 break
             mac_bytes = data[offset : offset + 6]
-            # Format as standard MAC address
-            result["mac"] = ":".join(f"{b:02X}" for b in mac_bytes)
+            # Format as standard MAC address (reverse the byte order)
+            result["mac"] = ":".join(f"{b:02X}" for b in reversed(mac_bytes))
             offset += 6
 
         elif block_type == BLOCK_TYPE_MODEL:

--- a/tests/ble/test_manufacturer_data.py
+++ b/tests/ble/test_manufacturer_data.py
@@ -37,10 +37,11 @@ def test_parse_flags_only() -> None:
 
 def test_parse_mac_only() -> None:
     """Test parsing manufacturer data with MAC address only."""
-    # Block type 0x0A (MAC) + 6 bytes MAC address
+    # Block type 0x0A (MAC) + 6 bytes MAC address (stored in reverse order)
     data = bytes([BLOCK_TYPE_MAC, 0xC0, 0x49, 0xEF, 0x88, 0x73, 0xE8])
     result = parse_shelly_manufacturer_data({ALLTERCO_MFID: data})
-    assert result == {"mac": "C0:49:EF:88:73:E8"}
+    # MAC bytes are reversed when parsed
+    assert result == {"mac": "E8:73:88:EF:49:C0"}
 
 
 def test_parse_model_only() -> None:
@@ -65,7 +66,7 @@ def test_parse_all_blocks() -> None:
             0xEF,
             0x88,
             0x73,
-            0xE8,  # MAC
+            0xE8,  # MAC (stored in reverse order)
             BLOCK_TYPE_MODEL,
             0x34,
             0x12,  # model = 0x1234
@@ -74,7 +75,7 @@ def test_parse_all_blocks() -> None:
     result = parse_shelly_manufacturer_data({ALLTERCO_MFID: data})
     assert result == {
         "flags": 0x0007,
-        "mac": "C0:49:EF:88:73:E8",
+        "mac": "E8:73:88:EF:49:C0",  # MAC bytes are reversed when parsed
         "model_id": 0x1234,
     }
 


### PR DESCRIPTION
## Issue

When parsing the MAC address from Shelly Gen4 BLE manufacturer data, the bytes were being read in the wrong order. The MAC address is stored in reverse byte order in the manufacturer data, but the parser was reading them sequentially.

### Example:
- Manufacturer data bytes: `70 d6 c2 97 ba cc`
- Previous (incorrect) parsing: `70:D6:C2:97:BA:CC`
- Correct parsing: `CC:BA:97:C2:D6:70` (bytes reversed)
- Zeroconf name: `shelly1minig4-ccba97c2d670` ✓ matches!

This caused a mismatch between the MAC extracted from BLE and the MAC advertised via zeroconf after WiFi provisioning, breaking the handoff from BLE to WiFi setup.

## Fix

Reverse the MAC address bytes when parsing by using `reversed(mac_bytes)` in the manufacturer data parser.

```python
# Before
result["mac"] = ":".join(f"{b:02X}" for b in mac_bytes)

# After
result["mac"] = ":".join(f"{b:02X}" for b in reversed(mac_bytes))
```

## Testing

Updated all tests to expect the corrected byte order. All 18 manufacturer data tests pass.
