### PR TITLE
Add model_id for gen2 US plug

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -645,6 +645,7 @@ DEVICES = {
         min_fw_date=GEN2_MIN_FIRMWARE_DATE,
         gen=GEN2,
         supported=True,
+        model_id=0x1804,
     ),
     MODEL_PLUS_PM_MINI: ShellyDevice(
         model=MODEL_PLUS_PM_MINI,


### PR DESCRIPTION
I couldn't find this in the shelly docs, but I was able to extract it from the adv data