### PR TITLE
Add missing models

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -967,7 +967,7 @@ DEVICES = {
         name="Shelly AZ H&T",
         min_fw_date=GEN3_MIN_FIRMWARE_DATE,
         gen=GEN3,
-        supported=True,
+        supported=False,
         model_id=0x1816,
     ),
     MODEL_AZ_PLUG: ShellyDevice(


### PR DESCRIPTION
Plug PM Gen3: https://kb.shelly.cloud/knowledge-base/shelly-plug-pm-gen3
EM Mini Gen4: https://kb.shelly.cloud/knowledge-base/shelly-em-mini-gen4
AZ H&T: https://kb.shelly.cloud/knowledge-base/shelly-az-h-t
Shutter: https://kb.shelly.cloud/knowledge-base/shelly-shutter
Pro Dimmer 0/1-10V PM: https://kb.shelly.cloud/knowledge-base/shelly-pro-dimmer-0-1-10v-pm