### PR TITLE
Add BLE model_id for Plus RGBW PM and Plus 0-10V Dimmer

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -547,6 +547,7 @@ DEVICES = {
         min_fw_date=GEN2_MIN_FIRMWARE_DATE,
         gen=GEN2,
         supported=True,
+        model_id=0x1070,
     ),
     MODEL_PLUS_1PM: ShellyDevice(
         model=MODEL_PLUS_1PM,
@@ -660,6 +661,7 @@ DEVICES = {
         min_fw_date=GEN2_MIN_FIRMWARE_DATE,
         gen=GEN2,
         supported=True,
+        model_id=0x1009,
     ),
     MODEL_PLUS_SMOKE: ShellyDevice(
         model=MODEL_PLUS_SMOKE,


### PR DESCRIPTION
## Summary
Added missing BLE model_id values for two Gen2 devices:

- Shelly Plus RGBW PM (SNDC-0D4P10WW): `0x1009`
- Shelly Plus 0-10V Dimmer (SNDM-00100WW): `0x1070`

Source: https://kb.shelly.cloud/knowledge-base/
