### PR TITLE
Add Wall Display X2i and `model_id` for Wall Display X2/XL

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -109,6 +109,7 @@ MODEL_PRO_EM3_400 = "SPEM-003CEBEU400"
 MODEL_PRO_RGBWW_PM = "SPDC-0D5PE16EU"
 MODEL_WALL_DISPLAY = "SAWD-0A1XX10EU1"
 MODEL_WALL_DISPLAY_X2 = "SAWD-2A1XX10EU1"
+MODEL_WALL_DISPLAY_X2I = " SAWD-5A1XX10EU0"
 MODEL_WALL_DISPLAY_XL = "SAWD-3A1XE10EU2"
 # Gen3 RPC based models
 MODEL_1_G3 = "S3SW-001X16EU"
@@ -883,6 +884,15 @@ DEVICES = {
         min_fw_date=GEN2_MIN_FIRMWARE_DATE,
         gen=GEN2,
         supported=True,
+        model_id=0x3002,
+    ),
+    MODEL_WALL_DISPLAY_X2I: ShellyDevice(
+        model=MODEL_WALL_DISPLAY_X2I,
+        name="Shelly Wall Display X2i",
+        min_fw_date=GEN2_MIN_FIRMWARE_DATE,
+        gen=GEN2,
+        supported=True,
+        model_id=0x3005,
     ),
     MODEL_WALL_DISPLAY_XL: ShellyDevice(
         model=MODEL_WALL_DISPLAY_XL,
@@ -890,6 +900,7 @@ DEVICES = {
         min_fw_date=GEN2_MIN_FIRMWARE_DATE,
         gen=GEN2,
         supported=True,
+        model_id=0x3003,
     ),
     MODEL_1_G3: ShellyDevice(
         model=MODEL_1_G3,


### PR DESCRIPTION
https://kb.shelly.cloud/knowledge-base/shelly-wall-display-x2i