### PR TITLE
Add model ID logging for discovered Shelly devices in BLE scanner

### DIFF
--- a/tools/ble_provision_wifi.py
+++ b/tools/ble_provision_wifi.py
@@ -81,7 +81,7 @@ class ShellyScannerAll:
     def detection_callback(
         self,
         device: BLEDevice,
-        advertisement_data: AdvertisementData,  # noqa: ARG002
+        advertisement_data: AdvertisementData,
     ) -> None:
         """Handle device detection."""
         # Only include devices with names starting with "Shelly"


### PR DESCRIPTION
To help capturing model ids for devices:
<img width="747" height="218" alt="image" src="https://github.com/user-attachments/assets/17d759f8-8270-4af5-9b39-a344954cb1b3" />
