### PR TITLE
Add venv path for ty hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,5 @@ repos:
     hooks:
       - id: ty-check
         files: ^aioshelly/.+\.py$
+        args:
+          - --python=venv


### PR DESCRIPTION
I noticed that the ty pre-commit hook is looking for `venv` in the wrong folder (`./.venv`). This fixes the problem.