### PR TITLE
Add information about Flood S Gen4

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -150,6 +150,7 @@ MODEL_CURY_G4 = "S4PB-00CU000002"
 MODEL_DIMMER_G4 = "S4DM-0A101WWL"
 MODEL_EM_MINI_G4 = "S4EM-001PXCEU16"
 MODEL_FLOOD_G4 = "S4SN-0071A"
+MODEL_FLOOD_S_G4 = "S4SN-0071Z"
 MODEL_I4_G4 = "S4SN-0A24X"
 MODEL_PLUG_US_G4 = "S4PL-00116US"
 MODEL_POWER_STRIP_4_G4 = "S4PL-00416EU"
@@ -1246,6 +1247,14 @@ DEVICES = {
         gen=GEN4,
         supported=True,
         model_id=0x1822,
+    ),
+    MODEL_FLOOD_S_G4: ShellyDevice(
+        model=MODEL_FLOOD_S_G4,
+        name="Shelly Flood S Gen4",
+        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
+        gen=GEN4,
+        supported=True,
+        model_id=0x1826,
     ),
     MODEL_PLUG_US_G4: ShellyDevice(
         model=MODEL_PLUG_US_G4,


### PR DESCRIPTION
The device was publicly presented on March 6 https://www.youtube.com/watch?v=8kmluArquXI

```json
{
   "app": "FloodSensorG4",
   "auth_domain": null,
   "auth_en": false,
   "enhanced_security": false,
   "fw_id": "20260115-183849/gad8663f",
   "gen": 4,
   "id": "shellyfloodsg4-aabbccddeeff",
   "mac": "AABBCCDDEEFF",
   "matter": false,
   "model": "S4SN-0071Z",
   "name": "Shelly Flood S Gen4",
   "slot": 0,
   "ver": "1.8.99-dev154678"
}
```