### PR TITLE
Bump orjson to 3.11.6 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "bleak-retry-connector>=3.0.0",
   "bluetooth-data-tools>=1.28.0",
   "habluetooth>=3.42.0",
-  "orjson>=3.8.1",
+  "orjson>=3.11.6",
   "yarl",
   "zeroconf>=0.148.0"
 ]


### PR DESCRIPTION
Security reason https://github.com/advisories/GHSA-hx9q-6w63-j58v

HA core repo uses orjson 3.11.7

https://github.com/home-assistant/core/blob/171b8dfa89e47550829dbe35c601b67dc006122a/requirements.txt#L37