### PR TITLE
Remove misleading class assignment

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -526,7 +526,6 @@ class Block:
     """Shelly CoAP block."""
 
     TYPES: ClassVar[dict] = {}
-    type = None
 
     def __init_subclass__(cls, blk_type: str = "", **kwargs: Any) -> None:
         """Initialize a subclass, register if possible."""


### PR DESCRIPTION
`Block.type` is set during `__init__` to a `str`. Remove the misleading assignment to `None` at class level.

https://github.com/home-assistant-libs/aioshelly/blob/5ede67b555f8f2a23a9f895619b3ffb1acace5a0/aioshelly/block_device/device.py#L543-L547