### PR TITLE
Handle mixed-case MAC address matching

### DIFF
--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -116,7 +116,7 @@ async def get_info(
         raise error from err
 
     mac = result["mac"]
-    if device_mac and device_mac != mac:
+    if device_mac and device_mac.lower() != mac.lower():
         error = MacAddressMismatchError(f"Input MAC: {device_mac}, Shelly MAC: {mac}")
         _LOGGER.debug("host %s:%s: error: %r", ip_address, port, error)
         raise error

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -681,7 +681,7 @@ class RpcDevice:
 
         mac = self.shelly["mac"]
         device_mac = self.options.device_mac
-        if device_mac and device_mac != mac:
+        if device_mac and device_mac.lower() != mac.lower():
             raise MacAddressMismatchError(f"Input MAC: {device_mac}, Shelly MAC: {mac}")
 
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetConfig", None)]

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -837,6 +837,34 @@ async def test_device_mac_address_mismatch(
 
 
 @pytest.mark.asyncio
+async def test_device_mac_address_mixed_case(
+    client_session: ClientSession,
+    ws_context: WsServer,
+    blu_gateway_device_info: dict[str, Any],
+    blu_gateway_config: dict[str, Any],
+    blu_gateway_status: dict[str, Any],
+    blu_gateway_remote_config: dict[str, Any],
+    blu_gateway_components: dict[str, Any],
+) -> None:
+    """Test RpcDevice initialize method when MAC differs in string case only."""
+    options = ConnectionOptions("10.10.10.10", device_mac="aabbccddeeff")
+
+    rpc_device = await RpcDevice.create(client_session, ws_context, options)
+    rpc_device.call_rpc_multiple = AsyncMock()
+
+    rpc_device.call_rpc_multiple.side_effect = [
+        [blu_gateway_device_info],
+        [blu_gateway_config, blu_gateway_status, blu_gateway_components],
+        [blu_gateway_remote_config],
+    ]
+
+    await rpc_device.initialize()
+
+    assert rpc_device.initialized is True
+    assert rpc_device.status is not None
+
+
+@pytest.mark.asyncio
 async def test_cover_update_status(
     rpc_device: RpcDevice,
     shelly2pmg3_status: dict[str, Any],

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -115,6 +115,29 @@ async def test_get_info_mac_mismatch() -> None:
     await session.close()
 
 
+@pytest.mark.asyncio
+async def test_get_info_mac_mixed_case() -> None:
+    """Test get_info function when MAC differs in string case only."""
+    mock_response = await load_device_fixture("shellyplus2pm", "shelly.json")
+    ip_address = "10.10.10.10"
+
+    session = ClientSession()
+
+    with aioresponses() as session_mock:
+        session_mock.get(
+            URL.build(
+                scheme="http", host=ip_address, port=DEFAULT_HTTP_PORT, path="/shelly"
+            ),
+            payload=mock_response,
+        )
+
+        result = await get_info(session, ip_address, "aabbccddeeff")
+
+    await session.close()
+
+    assert result == mock_response
+
+
 @pytest.mark.parametrize(
     ("exc", "expected_exc"),
     [


### PR DESCRIPTION
If we end up with one side providing upper-case and the other a lower-case string form of the MAC address, that should still be considered a match.  Even better would be to parse and compare as a more specific datatype, but normalizing the strings is probably good enough for now.