### PR TITLE
Fix RPC authentication for Shelly 2.0.0 firmware

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -9,7 +9,6 @@ import hashlib
 import logging
 import secrets
 import socket
-import time
 from asyncio import Task, tasks
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
@@ -113,15 +112,9 @@ class AuthData:
 
     def get_auth(self) -> dict[str, Any]:
         """Get auth for RPC calls with current nc value."""
-        # Generate cnonce based on nonce type
-        old_firmware = isinstance(self.nonce, int)
-        if old_firmware:
-            cnonce = int(time.time())
-        else:
-            random_bytes = secrets.token_bytes(16)
-            cnonce = base64.b64encode(random_bytes).decode("ascii")
+        random_bytes = secrets.token_bytes(16)
+        cnonce = base64.b64encode(random_bytes).decode("ascii")
 
-        # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
         # Calculate response hash: SHA256(HA1:nonce:nc:cnonce:qop:HA2)
         hashed = hex_hash(f"{self.ha1}:{self.nonce}:{self.nc}:{cnonce}:auth:{HA2}")
 
@@ -136,8 +129,7 @@ class AuthData:
         }
 
         # Increment nc after each auth calculation
-        if not old_firmware:
-            self.nc += 1
+        self.nc += 1
 
         return frame
 

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import contextlib
 import hashlib
 import logging
 import secrets
@@ -36,10 +35,8 @@ from yarl import URL
 from ..const import (
     DEFAULT_HTTP_PORT,
     NOTIFY_WS_CLOSED,
-    UNDEFINED,
     WS_API_URL,
     WS_HEARTBEAT,
-    UndefinedType,
 )
 from ..exceptions import (
     ConnectionClosed,
@@ -86,6 +83,11 @@ def hex_hash(message: str) -> str:
     return hashlib.sha256(message.encode("utf-8")).hexdigest()
 
 
+def _current_task_cancelled() -> bool:
+    """Return whether the currently running task has been cancelled."""
+    return bool((current_task := asyncio.current_task()) and current_task.cancelled())
+
+
 HA2 = hex_hash("dummy_method:dummy_uri")
 
 
@@ -107,7 +109,11 @@ class AuthData:
     def update_challenge(self, auth_challenge: dict[str, Any]) -> None:
         """Update authentication challenge data from server."""
         self.nonce = auth_challenge["nonce"]
-        self.algorithm = auth_challenge["algorithm"]
+        # The only algorithm currently supported is SHA-256
+        if self.algorithm != auth_challenge["algorithm"]:
+            raise InvalidAuthError(
+                f"Unsupported auth algorithm: {auth_challenge['algorithm']}"
+            )
         self.nc = auth_challenge.get("nc", 1)
 
     def get_auth(self) -> dict[str, Any]:
@@ -173,7 +179,7 @@ class RPCCall:
         self.src = session.src
         self.dst = session.dst
         self.resolve = resolve
-        self.result: dict[str, Any] | UndefinedType = UNDEFINED
+        self.result: dict[str, Any] = {}
 
     def __repr__(self) -> str:
         """Return representation of the call."""
@@ -186,8 +192,7 @@ class RPCCall:
             ">"
         )
 
-    @property
-    def request_frame(self) -> dict[str, Any]:
+    def build_request_frame(self) -> dict[str, Any]:
         """Request frame."""
         msg: dict[str, Any] = {
             "id": self.call_id,
@@ -284,8 +289,11 @@ class WsRPC(WsBase):
         """Disconnect all sessions."""
         if self._rx_task is not None:
             self._rx_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            try:
                 await self._rx_task
+            except asyncio.CancelledError:
+                if _current_task_cancelled():
+                    raise
             self._rx_task = None
         if self._client is None:
             return
@@ -468,7 +476,7 @@ class WsRPC(WsBase):
                     self._loop.create_future(),
                 )
                 self._calls[call_id] = call
-                await self._send_json(call.request_frame)
+                await self._send_json(call.build_request_frame())
 
                 # Wait response
                 response = await call.resolve
@@ -486,9 +494,12 @@ class WsRPC(WsBase):
                     )
                 call.result = response["result"]
         except TimeoutError as exc:
-            with contextlib.suppress(asyncio.CancelledError):
-                call.resolve.cancel()
+            call.resolve.cancel()
+            try:
                 await call.resolve
+            except asyncio.CancelledError:
+                if _current_task_cancelled():
+                    raise
             # Ensure the call is removed from the calls dict
             # on failure
             self._calls.pop(call.call_id, None)
@@ -514,14 +525,16 @@ class WsRPC(WsBase):
             # sequential: each call uses fresh nc from prior challenge,
             # first call seeds the nonce via 401 challenge
             results = []
+            deadline = self._loop.time() + timeout
             for method, params in calls:
+                remaining = deadline - self._loop.time()
                 results.append(
-                    await self._rpc_call_with_auth_retry(method, params, timeout)
+                    await self._rpc_call_with_auth_retry(method, params, remaining)
                 )
             return results
 
         results = await self._rpc_calls(calls, timeout)
-        return [call.result for call in results if call.result is not UNDEFINED]
+        return [call.result for call in results]
 
     async def _rpc_calls(
         self, rpc_calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: float
@@ -549,7 +562,7 @@ class WsRPC(WsBase):
                     call = RPCCall(call_id, method, params, self._session, future)
                     sent_calls.append(call)
                     self._calls[call_id] = call
-                    await self._send_json(call.request_frame)
+                    await self._send_json(call.build_request_frame())
 
                 # Wait for all the responses
                 for call in sent_calls:
@@ -562,9 +575,12 @@ class WsRPC(WsBase):
                         call.result = response["result"]
         except TimeoutError as exc:
             for call in sent_calls:
-                with contextlib.suppress(asyncio.CancelledError):
-                    call.resolve.cancel()
+                call.resolve.cancel()
+                try:
                     await call.resolve
+                except asyncio.CancelledError:
+                    if _current_task_cancelled():
+                        raise
                 # Ensure the call is removed from the calls dict
                 # on failure
                 self._calls.pop(call.call_id, None)

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -237,7 +237,6 @@ class WsRPC(WsBase):
     ) -> None:
         """Initialize WsRPC class."""
         super().__init__()
-        self._auth_data: AuthData | None = None
         self._ip_address = ip_address
         self._port = port
         self._on_notification = on_notification
@@ -303,8 +302,7 @@ class WsRPC(WsBase):
 
     def set_auth_data(self, realm: str, username: str, password: str) -> None:
         """Set authentication data and generate session auth."""
-        self._auth_data = AuthData(realm, username, password)
-        self._session.auth_data = self._auth_data
+        self._session.auth_data = AuthData(realm, username, password)
 
     async def _handle_call(self, frame_id: str) -> None:
         if TYPE_CHECKING:
@@ -432,7 +430,7 @@ class WsRPC(WsBase):
         self,
         method: str,
         params: dict[str, Any] | None = None,
-        timeout: int = 10,
+        timeout: float = 10.0,
     ) -> dict[str, Any]:
         """Websocket RPC call."""
         return (await self.calls([(method, params)], timeout))[0]
@@ -451,56 +449,91 @@ class WsRPC(WsBase):
         if code != HTTPStatus.UNAUTHORIZED.value:
             raise RpcCallError(code, msg)
 
-        if allow_auth_retry and self._auth_data is not None:
+        if allow_auth_retry and self._session.auth_data is not None:
             return
 
         raise InvalidAuthError(msg)
+
+    async def _rpc_call_with_auth_retry(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 10.0,
+        allow_auth_retry: bool = True,
+    ) -> dict[str, Any]:
+        """Websocket RPC call with authentication retry."""
+        if self._client is None:
+            raise RuntimeError("Not connected")
+
+        try:
+            async with asyncio.timeout(timeout):
+                call_id = self._next_id
+                call = RPCCall(
+                    call_id,
+                    method,
+                    params,
+                    self._session,
+                    self._loop.create_future(),
+                )
+                self._calls[call_id] = call
+                await self._send_json(call.request_frame)
+
+                # Wait response
+                response = await call.resolve
+                if "result" not in response:
+                    self._raise_for_unrecoverable_errors(response, allow_auth_retry)
+                    auth_challenge = json_loads(response["error"]["message"])
+                    if TYPE_CHECKING:
+                        assert self._session.auth_data
+                    self._session.auth_data.update_challenge(auth_challenge)
+                    return await self._rpc_call_with_auth_retry(
+                        method,
+                        params,
+                        timeout,
+                        allow_auth_retry=False,
+                    )
+                call.result = response["result"]
+        except TimeoutError as exc:
+            with contextlib.suppress(asyncio.CancelledError):
+                call.resolve.cancel()
+                await call.resolve
+            # Ensure the call is removed from the calls dict
+            # on failure
+            self._calls.pop(call.call_id, None)
+            raise DeviceConnectionTimeoutError(call) from exc
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "result(%s:%s): %s(%s) -> %s",
+                self._ip_address,
+                self._port,
+                call.method,
+                call.params,
+                call.result,
+            )
+
+        return call.result
 
     async def calls(
         self, calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: float = 10.0
     ) -> list[dict[str, Any]]:
         """Websocket RPC calls."""
-        # Try request with initial/last call auth data
-        all_successful, results = await self._rpc_calls(calls, timeout)
-        if all_successful:
-            # If all_successful, return results immediately
-            # mypy does not know that .result is never
-            # None when all_successful is True so we need
-            # to ignore the type check here
-            return [call.result for call in results if call.result is not UNDEFINED]
+        if self._session.auth_data is not None:
+            # sequential: each call uses fresh nc from prior challenge,
+            # first call seeds the nonce via 401 challenge
+            results = []
+            for method, params in calls:
+                results.append(
+                    await self._rpc_call_with_auth_retry(method, params, timeout)
+                )
+            return results
 
-        # Partial success, try to update auth and retry
-        successful: list[dict[str, Any]] = []
-        for call in calls:
-            _, results = await self._rpc_calls([call], timeout)
-            res = results[0]
-            if (result := res.result) is not UNDEFINED:
-                resp = res.resolve.result()
-                if "error" in resp:
-                    self._raise_for_unrecoverable_errors(resp, allow_auth_retry=True)
-                    # Update auth from response and try with new auth data
-                    # If we have multiple calls, we only need to update auth once
-                    if TYPE_CHECKING:
-                        assert self._auth_data is not None
-                    auth_challenge = json_loads(resp["error"]["message"])
-                    self._auth_data.update_challenge(auth_challenge)
-                    _, results = await self._rpc_calls([call], timeout)
-                    res = results[0]
-                    if (
-                        result := res.result
-                    ) is UNDEFINED or "error" in res.resolve.result():
-                        self._raise_for_unrecoverable_errors(
-                            res.resolve.result(), allow_auth_retry=False
-                        )
-
-                if result is not UNDEFINED:
-                    successful.append(result)
-
-        return successful
+        results = await self._rpc_calls(calls, timeout)
+        return [call.result for call in results if call.result is not UNDEFINED]
 
     async def _rpc_calls(
         self, rpc_calls: Iterable[tuple[str, dict[str, Any] | None]], timeout: float
-    ) -> tuple[bool, list[RPCCall]]:
+    ) -> list[RPCCall]:
         """Websocket RPC call.
 
         calls is a tuple of tuples of
@@ -514,7 +547,6 @@ class WsRPC(WsBase):
 
         sent_calls: list[RPCCall] = []
         loop = self._loop
-        all_successful: bool = True
         future: asyncio.Future[dict[str, Any]]
 
         try:
@@ -531,9 +563,9 @@ class WsRPC(WsBase):
                 for call in sent_calls:
                     response = await call.resolve
                     if "result" not in response:
-                        all_successful = False
-                        if "error" in response:
-                            call.result = {"error": response["error"]}
+                        self._raise_for_unrecoverable_errors(
+                            response, allow_auth_retry=False
+                        )
                     else:
                         call.result = response["result"]
         except TimeoutError as exc:
@@ -557,7 +589,7 @@ class WsRPC(WsBase):
                     call.result,
                 )
 
-        return all_successful, sent_calls
+        return sent_calls
 
     async def _send_json(self, data: dict[str, Any]) -> None:
         """Send json frame to device."""

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import hashlib
 import logging
+import secrets
 import socket
 import time
 from asyncio import Task, tasks
@@ -95,28 +97,49 @@ class AuthData:
     realm: str
     username: str
     password: str
+    nonce: str = ""
+    algorithm: str = "SHA-256"
+    nc: int = 0
 
     def __post_init__(self) -> None:
         """Call after initialization."""
         self.ha1 = hex_hash(f"{self.username}:{self.realm}:{self.password}")
 
-    def get_auth(self, nonce: int | None = None, n_c: int = 1) -> dict[str, Any]:
-        """Get auth for RPC calls."""
-        cnonce = int(time.time())
-        if nonce is None:
-            nonce = cnonce - 1800
+    def update_challenge(self, auth_challenge: dict[str, Any]) -> None:
+        """Update authentication challenge data from server."""
+        self.nonce = auth_challenge["nonce"]
+        self.algorithm = auth_challenge["algorithm"]
+        self.nc = auth_challenge.get("nc", 1)
+
+    def get_auth(self) -> dict[str, Any]:
+        """Get auth for RPC calls with current nc value."""
+        # Generate cnonce based on nonce type
+        old_firmware = isinstance(self.nonce, int)
+        if old_firmware:
+            cnonce = int(time.time())
+        else:
+            random_bytes = secrets.token_bytes(16)
+            cnonce = base64.b64encode(random_bytes).decode("ascii")
 
         # https://shelly-api-docs.shelly.cloud/gen2/Overview/CommonDeviceTraits/#authentication-over-websocket
-        hashed = hex_hash(f"{self.ha1}:{nonce}:{n_c}:{cnonce}:auth:{HA2}")
+        # Calculate response hash: SHA256(HA1:nonce:nc:cnonce:qop:HA2)
+        hashed = hex_hash(f"{self.ha1}:{self.nonce}:{self.nc}:{cnonce}:auth:{HA2}")
 
-        return {
+        frame = {
             "realm": self.realm,
             "username": self.username,
-            "nonce": nonce,
+            "nonce": self.nonce,
+            "nc": self.nc,
             "cnonce": cnonce,
             "response": hashed,
-            "algorithm": "SHA-256",
+            "algorithm": self.algorithm,
         }
+
+        # Increment nc after each auth calculation
+        if not old_firmware:
+            self.nc += 1
+
+        return frame
 
 
 @dataclass
@@ -125,14 +148,14 @@ class SessionData:
 
     src: str | None
     dst: str | None
-    auth: dict[str, Any] | None
+    auth_data: AuthData | None
 
 
 class RPCCall:
     """RPCCall class."""
 
     __slots__ = (
-        "auth",
+        "auth_data",
         "call_id",
         "dst",
         "method",
@@ -151,7 +174,7 @@ class RPCCall:
         resolve: asyncio.Future[dict[str, Any]],
     ) -> None:
         """Initialize RPC class."""
-        self.auth = session.auth
+        self.auth_data = session.auth_data
         self.call_id = call_id
         self.params = params
         self.method = method
@@ -174,14 +197,18 @@ class RPCCall:
     @property
     def request_frame(self) -> dict[str, Any]:
         """Request frame."""
-        msg = {
+        msg: dict[str, Any] = {
             "id": self.call_id,
             "method": self.method,
             "src": self.src,
         }
-        for obj in ("params", "dst", "auth"):
-            if getattr(self, obj) is not None:
-                msg[obj] = getattr(self, obj)
+        if self.params is not None:
+            msg["params"] = self.params
+        if self.dst is not None:
+            msg["dst"] = self.dst
+        # Calculate auth on-demand with current nc
+        if self.auth_data is not None and self.auth_data.nonce:
+            msg["auth"] = self.auth_data.get_auth()
         return msg
 
 
@@ -277,7 +304,7 @@ class WsRPC(WsBase):
     def set_auth_data(self, realm: str, username: str, password: str) -> None:
         """Set authentication data and generate session auth."""
         self._auth_data = AuthData(realm, username, password)
-        self._session.auth = self._auth_data.get_auth()
+        self._session.auth_data = self._auth_data
 
     async def _handle_call(self, frame_id: str) -> None:
         if TYPE_CHECKING:
@@ -443,35 +470,31 @@ class WsRPC(WsBase):
             return [call.result for call in results if call.result is not UNDEFINED]
 
         # Partial success, try to update auth and retry
-        to_retry: list[RPCCall] = []
         successful: list[dict[str, Any]] = []
-        for call in results:
-            if (result := call.result) is not UNDEFINED:
-                successful.append(result)
-                continue
-            resp = call.resolve.result()
-            self._raise_for_unrecoverable_errors(resp, allow_auth_retry=True)
-            if not to_retry:
-                # Update auth from response and try with new auth data
-                # If we have multiple calls, we only need to update auth once
-                if TYPE_CHECKING:
-                    # _raise_for_unrecoverable_errors ensures that auth_data is not None
-                    assert self._auth_data is not None
-                auth = json_loads(resp["error"]["message"])
-                self._session.auth = self._auth_data.get_auth(
-                    auth["nonce"], auth.get("nc", 1)
-                )
-            to_retry.append(call)
+        for call in calls:
+            _, results = await self._rpc_calls([call], timeout)
+            res = results[0]
+            if (result := res.result) is not UNDEFINED:
+                resp = res.resolve.result()
+                if "error" in resp:
+                    self._raise_for_unrecoverable_errors(resp, allow_auth_retry=True)
+                    # Update auth from response and try with new auth data
+                    # If we have multiple calls, we only need to update auth once
+                    if TYPE_CHECKING:
+                        assert self._auth_data is not None
+                    auth_challenge = json_loads(resp["error"]["message"])
+                    self._auth_data.update_challenge(auth_challenge)
+                    _, results = await self._rpc_calls([call], timeout)
+                    res = results[0]
+                    if (
+                        result := res.result
+                    ) is UNDEFINED or "error" in res.resolve.result():
+                        self._raise_for_unrecoverable_errors(
+                            res.resolve.result(), allow_auth_retry=False
+                        )
 
-        _, results = await self._rpc_calls(
-            [(call.method, call.params) for call in to_retry], timeout
-        )
-        for call in results:
-            if (result := call.result) is UNDEFINED:
-                resp = call.resolve.result()
-                self._raise_for_unrecoverable_errors(resp, allow_auth_retry=False)
-            else:
-                successful.append(result)
+                if result is not UNDEFINED:
+                    successful.append(result)
 
         return successful
 
@@ -509,8 +532,10 @@ class WsRPC(WsBase):
                     response = await call.resolve
                     if "result" not in response:
                         all_successful = False
-                        continue
-                    call.result = response["result"]
+                        if "error" in response:
+                            call.result = {"error": response["error"]}
+                    else:
+                        call.result = response["result"]
         except TimeoutError as exc:
             for call in sent_calls:
                 with contextlib.suppress(asyncio.CancelledError):

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -43,6 +43,7 @@ async def test_device_wscall_auth_retry(ws_rpc_with_auth: WsRPCMocker) -> None:
         "shellyplus2pm", "Cover.Close_success"
     )
     calls = [("Cover.Close", {"id": 0})]
+    ws_rpc_with_auth.set_auth_data("auth_domain", "username", "password")
     responses = [cover_close_auth_fail, cover_close_success]
     results = await ws_rpc_with_auth.calls_with_mocked_responses(calls, responses)
     assert results[0] == cover_close_success["result"]

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -1,11 +1,67 @@
 """Tests for rpc_device.wsrpc module."""
 
-import pytest
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
 
-from aioshelly.exceptions import InvalidAuthError
+import pytest
+from aiohttp.http_websocket import WSMessage, WSMsgType
+
+from aioshelly.exceptions import (
+    ConnectionClosed,
+    DeviceConnectionTimeoutError,
+    InvalidAuthError,
+    InvalidMessage,
+)
+from aioshelly.rpc_device.wsrpc import AuthData, _receive_json_or_raise
 
 from . import load_device_fixture
 from .conftest import WsRPCMocker
+
+
+def test_receive_json_or_raise_text_returns_decoded_json() -> None:
+    """Test text message with JSON payload returns decoded dict."""
+    msg = WSMessage(WSMsgType.TEXT, '{"key":"value","n":1}', None)
+
+    assert _receive_json_or_raise(msg) == {"key": "value", "n": 1}
+
+
+def test_receive_json_or_raise_text_invalid_json_raises_invalid_message() -> None:
+    """Test text message with invalid JSON raises InvalidMessage."""
+    msg = WSMessage(WSMsgType.TEXT, "not-json", None)
+
+    with pytest.raises(InvalidMessage, match="Received invalid JSON: not-json"):
+        _receive_json_or_raise(msg)
+
+
+@pytest.mark.parametrize(
+    "msg_type",
+    [WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING],
+)
+def test_receive_json_or_raise_close_types_raise_connection_closed(
+    msg_type: WSMsgType,
+) -> None:
+    """Test close-related message types raise ConnectionClosed."""
+    msg = WSMessage(msg_type, None, None)
+
+    with pytest.raises(ConnectionClosed, match="Connection was closed"):
+        _receive_json_or_raise(msg)
+
+
+def test_receive_json_or_raise_error_type_raises_invalid_message() -> None:
+    """Test error message type raises InvalidMessage."""
+    msg = WSMessage(WSMsgType.ERROR, None, None)
+
+    with pytest.raises(InvalidMessage, match="Received message error"):
+        _receive_json_or_raise(msg)
+
+
+def test_receive_json_or_raise_non_text_type_raises_invalid_message() -> None:
+    """Test non-text and non-close message type raises InvalidMessage."""
+    msg = WSMessage(WSMsgType.BINARY, b"bytes", None)
+
+    with pytest.raises(InvalidMessage, match="Received non-Text message"):
+        _receive_json_or_raise(msg)
 
 
 @pytest.mark.asyncio
@@ -47,3 +103,117 @@ async def test_device_wscall_auth_retry(ws_rpc_with_auth: WsRPCMocker) -> None:
     responses = [cover_close_auth_fail, cover_close_success]
     results = await ws_rpc_with_auth.calls_with_mocked_responses(calls, responses)
     assert results[0] == cover_close_success["result"]
+
+
+def test_auth_update_challenge_unsupported_algorithm() -> None:
+    """Test challenge update raises when algorithm is unsupported."""
+    auth_data = AuthData("auth_domain", "username", "password")
+
+    with pytest.raises(InvalidAuthError, match="Unsupported auth algorithm: SHA-1"):
+        auth_data.update_challenge({"nonce": "test_nonce", "algorithm": "SHA-1"})
+
+
+@pytest.mark.asyncio
+async def test_wscall_not_connected_without_auth(ws_rpc: WsRPCMocker) -> None:
+    """Test call raises when websocket is not connected and auth is not set."""
+    await ws_rpc.disconnect()
+
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await ws_rpc.calls([("Shelly.GetConfig", None)])
+
+
+@pytest.mark.asyncio
+async def test_wscall_not_connected_with_auth(ws_rpc: WsRPCMocker) -> None:
+    """Test call raises when websocket is not connected and auth is set."""
+    await ws_rpc.disconnect()
+
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await ws_rpc.calls([("Shelly.GetConfig", None)])
+
+
+@pytest.mark.asyncio
+async def test_wscall_timeout_without_auth_raises_device_connection_timeout_error(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test websocket call timeout raises DeviceConnectionTimeoutError without auth."""
+    with (
+        patch.object(ws_rpc, "_send_next_response", new=AsyncMock(return_value=None)),
+        pytest.raises(DeviceConnectionTimeoutError),
+    ):
+        await ws_rpc.calls([("Shelly.GetConfig", None)], timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_wscall_timeout_with_auth_raises_device_connection_timeout_error(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test websocket call timeout raises DeviceConnectionTimeoutError with auth."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    with (
+        patch.object(ws_rpc, "_send_next_response", new=AsyncMock(return_value=None)),
+        pytest.raises(DeviceConnectionTimeoutError),
+    ):
+        await ws_rpc.calls([("Shelly.GetConfig", None)], timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_wscall_timeout_with_auth_reraises_cancelled_error(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test timeout cleanup re-raises CancelledError when current task is cancelled."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    with (
+        patch.object(ws_rpc, "_send_next_response", new=AsyncMock(return_value=None)),
+        patch("aioshelly.rpc_device.wsrpc._current_task_cancelled", return_value=True),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await ws_rpc.calls([("Shelly.GetConfig", None)], timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_wscall_timeout_without_auth_reraises_cancelled_error(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test timeout cleanup re-raises CancelledError when current task is cancelled."""
+    with (
+        patch.object(ws_rpc, "_send_next_response", new=AsyncMock(return_value=None)),
+        patch("aioshelly.rpc_device.wsrpc._current_task_cancelled", return_value=True),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await ws_rpc.calls([("Shelly.GetConfig", None)], timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_wscall_debug_logs_result_without_auth(
+    ws_rpc: WsRPCMocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test non-auth call path logs result details at debug level."""
+    config_response = await load_device_fixture("shellyplugus", "Shelly.GetConfig")
+
+    with caplog.at_level(logging.DEBUG, logger="aioshelly.rpc_device.wsrpc"):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Shelly.GetConfig", None)], [config_response]
+        )
+
+    assert (
+        f"result(127.0.0.1:80): Shelly.GetConfig(None) -> {config_response['result']}"
+    ) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_wscall_debug_logs_result_with_auth(
+    ws_rpc: WsRPCMocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test auth call path logs result details at debug level."""
+    config_response = await load_device_fixture("shellyplugus", "Shelly.GetConfig")
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+
+    with caplog.at_level(logging.DEBUG, logger="aioshelly.rpc_device.wsrpc"):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Shelly.GetConfig", None)], [config_response]
+        )
+
+    assert (
+        f"result(127.0.0.1:80): Shelly.GetConfig(None) -> {config_response['result']}"
+    ) in caplog.text

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -133,6 +133,19 @@ async def test_wscall_not_connected_with_auth(ws_rpc: WsRPCMocker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_reraises_cancelled_error(ws_rpc: WsRPCMocker) -> None:
+    """Test disconnect re-raises CancelledError when current task is cancelled."""
+    ws_rpc._rx_task = asyncio.get_running_loop().create_future()
+    ws_rpc._rx_task.cancel()
+
+    with (
+        patch("aioshelly.rpc_device.wsrpc._current_task_cancelled", return_value=True),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await ws_rpc.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_wscall_timeout_without_auth_raises_device_connection_timeout_error(
     ws_rpc: WsRPCMocker,
 ) -> None:


### PR DESCRIPTION
In firmware 2.0.0 Shelly improved device security - [2.0.0-beta1 Changelog](https://shelly-api-docs.shelly.cloud/gen2/changelog#security) mainly improving brute-force protection and preventing replay attacks.

This PR updates WsRPC class, when authentication is enabled calls are sent sequentially due to needed results from previous calls, without authentication calls are send in parallel (unchanged)

Fixes https://github.com/home-assistant/core/issues/169007