### PR TITLE
Make `async_ensure_ble_enabled` compatible with firmware 2.0.0

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -106,7 +106,9 @@ async def async_ensure_ble_enabled(device: RpcDevice) -> bool:
     be enabled.
     """
     ble_config = await device.ble_getconfig()
-    if ble_config["enable"]:
+    # The enable property has been removed in firmware 2.0.0.
+    # Bluetooth scanning now auto-activates when needed by scripts.
+    if ble_config.get("enable", True):
         return False
     ble_enable = await device.ble_setconfig(enable=True, enable_rpc=False)
     if not ble_enable["restart_required"]:

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -38,15 +39,23 @@ async def test_create_scanner(
     assert scanner.current_mode == current_mode
 
 
+@pytest.mark.parametrize(
+    "ble_config",
+    [
+        {
+            "enable": True,
+            "rpc": {"enable": False},
+        },
+        {"rpc": {"enable": False}},
+    ],
+)
 @pytest.mark.asyncio
 async def test_async_ensure_ble_enabled_already_enabled(
     mock_rpc_device: AsyncMock,
+    ble_config: dict[str, Any],
 ) -> None:
     """Test async_ensure_ble_enabled method when BLE is already enabled."""
-    mock_rpc_device.ble_getconfig.return_value = {
-        "enable": True,
-        "rpc": {"enable": False},
-    }
+    mock_rpc_device.ble_getconfig.return_value = ble_config
 
     result = await async_ensure_ble_enabled(mock_rpc_device)
     assert result is False

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -46,7 +46,7 @@ async def test_create_scanner(
             "enable": True,
             "rpc": {"enable": False},
         },
-        {"rpc": {"enable": False}},
+        {"rpc": {"enable": False}},  # for fw 2.0.0+ where "enable" is removed
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/coordinator.py", line 729, in _async_connected
    await self._async_run_connected_events()
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/coordinator.py", line 744, in _async_run_connected_events
    await self._async_connect_ble_scanner()
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/coordinator.py", line 770, in _async_connect_ble_scanner
    if await async_ensure_ble_enabled(self.device):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/aioshelly/ble/__init__.py", line 109, in async_ensure_ble_enabled
    if ble_config["enable"]:
       ~~~~~~~~~~^^^^^^^^^^
KeyError: 'enable'
```