### PR TITLE
Ensure RPC auth challenge nc is an integer

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -114,7 +114,7 @@ class AuthData:
             raise InvalidAuthError(
                 f"Unsupported auth algorithm: {auth_challenge['algorithm']}"
             )
-        self.nc = auth_challenge.get("nc", 1)
+        self.nc = int(auth_challenge.get("nc", 1))
 
     def get_auth(self) -> dict[str, Any]:
         """Get auth for RPC calls with current nc value."""

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -114,6 +114,8 @@ class AuthData:
             raise InvalidAuthError(
                 f"Unsupported auth algorithm: {auth_challenge['algorithm']}"
             )
+
+        # Shelly WallDisplay sends nc as a string but it should be an integer
         self.nc = int(auth_challenge.get("nc", 1))
 
     def get_auth(self) -> dict[str, Any]:


### PR DESCRIPTION
Shelly Wall Display uses string for `nc` counter during auth challenge, casting to int works on all devices, tested with:
- Wall Display firmware 2.3.3
- Wall Display firmware 2.6.0-beta
- Shelly Pro 1 firmware 1.4.4
- Shelly 1PM Gen3 2.0.0-beta1
