### PR TITLE
Use RPC authentication only if enabled on the device

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -674,7 +674,8 @@ class RpcDevice:
         self._shelly = await self.call_rpc("Shelly.GetDeviceInfo")
         # Auth only supported on WebSocket transport
         if (
-            self.options.username
+            self.requires_auth
+            and self.options.username
             and self.options.password
             and isinstance(self._rpc, WsRPC)
         ):

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -379,6 +379,32 @@ async def test_device_initialize_and_shutdown(
     assert rpc_device._unsub_ws is None
 
 
+@pytest.mark.parametrize("auth_en", [False, True])
+@pytest.mark.asyncio
+async def test_device_init_auth_matches_device_setting(
+    rpc_device: RpcDevice,
+    blu_gateway_device_info: dict[str, Any],
+    blu_gateway_config: dict[str, Any],
+    blu_gateway_status: dict[str, Any],
+    blu_gateway_remote_config: dict[str, Any],
+    blu_gateway_components: dict[str, Any],
+    auth_en: bool,
+) -> None:
+    """Test RpcDevice initialize sets auth based on device auth_en setting."""
+    blu_gateway_device_info["auth_en"] = auth_en
+    rpc_device.call_rpc_multiple.side_effect = [
+        [blu_gateway_device_info],
+        [blu_gateway_config, blu_gateway_status, blu_gateway_components],
+        [blu_gateway_remote_config],
+    ]
+
+    await rpc_device.initialize()
+
+    assert rpc_device.connected is True
+    assert rpc_device.requires_auth is auth_en
+    assert bool(rpc_device._rpc._session.auth_data) is auth_en
+
+
 @pytest.mark.asyncio
 async def test_device_initialize_lock(
     rpc_device: RpcDevice,


### PR DESCRIPTION
When testing authentication I enabled it for few devices on my prod and later disabled it on all of them.
I noticed we still do the authentication process and send call sequentially instead of parallel calls since Home Assistant doesn't know it was disabled on the device.

Added a check to use authentication only if enabled on the device (`auth_en` flag from `Shelly.GetDeviceInfo` endpoint)

We don't need to change anything on Home Assistant side for this, if the user disable the authentication we ignore the provided credentials so the user doesn't need to do anything.

Tested on:
- Wall Display firmware 2.3.3
- Wall Display firmware 2.6.0-beta
- Shelly Pro 1 firmware 1.4.4
- Shelly 1PM Gen3 2.0.0-beta1