### PR TITLE
Add Gen4 models for Shelly 1L and Shelly 2L

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -1187,14 +1187,6 @@ DEVICES = {
         supported=True,
         model_id=0x1028,
     ),
-    MODEL_1_MINI_G4: ShellyDevice(
-        model=MODEL_1_MINI_G4,
-        name="Shelly 1 Mini Gen4",
-        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
-        gen=GEN4,
-        supported=True,
-        model_id=0x1030,
-    ),
     MODEL_1L_G4: ShellyDevice(
         model=MODEL_1L_G4,
         name="Shelly 1L Gen4",
@@ -1202,6 +1194,14 @@ DEVICES = {
         gen=GEN4,
         supported=True,
         model_id=0x1035,
+    ),
+    MODEL_1_MINI_G4: ShellyDevice(
+        model=MODEL_1_MINI_G4,
+        name="Shelly 1 Mini Gen4",
+        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
+        gen=GEN4,
+        supported=True,
+        model_id=0x1030,
     ),
     MODEL_1PM_G4: ShellyDevice(
         model=MODEL_1PM_G4,

--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -143,9 +143,11 @@ MODEL_SHUTTER_G3 = "S3SH-0A2P4EU"
 MODEL_X_MOD1 = "S3MX-0A"
 # Gen4 RPC based models
 MODEL_1_G4 = "S4SW-001X16EU"
+MODEL_1L_G4 = "S4SW-0A1X1EUL"
 MODEL_1_MINI_G4 = "S4SW-001X8EU"
 MODEL_1PM_G4 = "S4SW-001P16EU"
 MODEL_1PM_MINI_G4 = "S4SW-001P8EU"
+MODEL_2L_G4 = "S4SW-0A2X4EUL"
 MODEL_2PM_G4 = "S4SW-002P16EU"
 MODEL_CURY_G4 = "S4PB-00CU000002"
 MODEL_DIMMER_G4 = "S4DM-0A101WWL"
@@ -1193,6 +1195,14 @@ DEVICES = {
         supported=True,
         model_id=0x1030,
     ),
+    MODEL_1L_G4: ShellyDevice(
+        model=MODEL_1L_G4,
+        name="Shelly 1L Gen4",
+        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
+        gen=GEN4,
+        supported=True,
+        model_id=0x1035,
+    ),
     MODEL_1PM_G4: ShellyDevice(
         model=MODEL_1PM_G4,
         name="Shelly 1PM Gen4",
@@ -1208,6 +1218,14 @@ DEVICES = {
         gen=GEN4,
         supported=True,
         model_id=0x1031,
+    ),
+    MODEL_2L_G4: ShellyDevice(
+        model=MODEL_2L_G4,
+        name="Shelly 2L Gen4",
+        min_fw_date=GEN4_MIN_FIRMWARE_DATE,
+        gen=GEN4,
+        supported=True,
+        model_id=0x1034,
     ),
     MODEL_2PM_G4: ShellyDevice(
         model=MODEL_2PM_G4,


### PR DESCRIPTION

<img width="84" height="21" alt="Shelly 1L Gen4" src="https://github.com/user-attachments/assets/d6169e4e-fa59-4421-818f-a8090e662e9e" />

Discovered Shelly device: Shelly1LG4-ABCDEF123456 (AB:CD:EF:12:34:56), model_id: 0x1035

{
  "name": null,
  "id": "shelly1lg4-abcdef123456",
  "mac": "ABCDEF123456",
  "slot": 0,
  "model": "S4SW-0A1X1EUL",
  "gen": 4,
  "fw_id": "20251217-083356/g76b2b76",
  "ver": "1.8.99-xlg4samples0",
  "app": "S1LG4",
  "auth_en": false,
  "auth_domain": null,
  "matter": true,
  "enhanced_security": false
}

<img width="90" height="16" alt="Shelly 2L Gen4" src="https://github.com/user-attachments/assets/3d0db062-818f-4815-b9ea-4f86826b1859" />

Discovered Shelly device: Shelly2LG4-ABCDEF123456 (AB:CD:EF:12:34:56), model_id: 0x1034

{
  "name": null,
  "id": "shelly2lg4-abcdef123456",
  "mac": "ABCDEF123456",
  "slot": 0,
  "model": "S4SW-0A2X4EUL",
  "gen": 4,
  "fw_id": "20251217-083356/g76b2b76",
  "ver": "1.8.99-xlg4samples0",
  "app": "S2LG4",
  "auth_en": false,
  "auth_domain": null,
  "matter": true,
  "enhanced_security": false
}
