### PR TITLE
Add ability to update Uart/Lora Add-on

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -326,6 +326,11 @@ class RpcDevice:
         params = {"stage": "beta"} if beta else {"stage": "stable"}
         await self.call_rpc("Shelly.Update", params)
 
+    async def trigger_add_on_ota_update(self, timeout: int = 300) -> None:
+        """Trigger an add-on ota update."""
+        params = {"timeout": timeout}
+        await self.call_rpc("AddOn.Update", params)
+
     async def trigger_reboot(self, delay_ms: int = 1000) -> None:
         """Trigger a device reboot."""
         await self.call_rpc("Shelly.Reboot", {"delay_ms": delay_ms})

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -1045,6 +1045,16 @@ async def test_trigger_ota_update(rpc_device: RpcDevice) -> None:
 
 
 @pytest.mark.asyncio
+async def test_trigger_add_on_ota_update(rpc_device: RpcDevice) -> None:
+    """Test RpcDevice trigger_add_on_ota_update method."""
+    await rpc_device.trigger_add_on_ota_update(timeout=600)
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][0] == "AddOn.Update"
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][1] == {"timeout": 600}
+
+
+@pytest.mark.asyncio
 async def test_incorrect_shutdown(
     client_session: ClientSession,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
_Current official UART Add-On version - "2.1.1" supports: EU868, US915, BR915 RF plans for [Shelly LoRa](https://shelly-api-docs.shelly.cloud/gen2/Addons/ShellyLoRaAddon)_

https://shelly-api-docs.shelly.cloud/gen2/Addons/ShellyUartAddon#addonupdate-example