### PR TITLE
Fix directory typo in build script

### DIFF
--- a/script/environment.sh
+++ b/script/environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pip3 --disable-pip-version-check --no-cache-dir install uv
-uv venv venv --seed --clear
-source venv/bin/activate
+uv venv .venv --seed --clear
+source .venv/bin/activate
 uv pip install --no-cache-dir -e .[dev] .[lint]
 prek install


### PR DESCRIPTION
Repository is based on `.venv` not `venv`.