### PR TITLE
Implement on-demand active scan window on ShellyBLEScanner

### DIFF
--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -75,6 +75,27 @@ async def async_start_scanner(
     await device.script_start(ble_script_id)
 
 
+async def async_set_active_mode(device: RpcDevice, active: bool) -> None:
+    """Flip the BLE scanner's active mode via Script.Eval.
+
+    The script body exposes a ``setActive(v)`` function (see BLE_CODE
+    in const.py) that stops and restarts BLE.Scanner with the new
+    active flag. Driving the toggle via Script.Eval keeps the script
+    body byte-identical across windows, so the device's flash is not
+    rewritten on every transition.
+
+    Assumes the script is already installed and running via
+    ``async_start_scanner``. Raises RpcCallError if the script is not
+    installed on the device.
+    """
+    script_name_to_id = await _async_get_scripts_by_name(device)
+    if (ble_script_id := script_name_to_id.get(BLE_SCRIPT_NAME)) is None:
+        raise RpcCallError(0, f"{BLE_SCRIPT_NAME} script not installed")
+    await device.script_eval(
+        ble_script_id, f"setActive({'true' if active else 'false'})"
+    )
+
+
 def create_scanner(
     source: str,
     name: str,

--- a/aioshelly/ble/__init__.py
+++ b/aioshelly/ble/__init__.py
@@ -75,7 +75,21 @@ async def async_start_scanner(
     await device.script_start(ble_script_id)
 
 
-async def async_set_active_mode(device: RpcDevice, active: bool) -> None:
+async def async_get_ble_script_id(device: RpcDevice) -> int | None:
+    """Return the installed BLE integration script id, or None if absent.
+
+    Callers that toggle active mode repeatedly (e.g. the active-window
+    scheduler) should resolve the id once and cache it for the
+    lifetime of the script, since the id is stable until the script
+    is recreated.
+    """
+    script_name_to_id = await _async_get_scripts_by_name(device)
+    return script_name_to_id.get(BLE_SCRIPT_NAME)
+
+
+async def async_set_active_mode(
+    device: RpcDevice, script_id: int, active: bool
+) -> None:
     """Flip the BLE scanner's active mode via Script.Eval.
 
     The script body exposes a ``setActive(v)`` function (see BLE_CODE
@@ -84,16 +98,11 @@ async def async_set_active_mode(device: RpcDevice, active: bool) -> None:
     body byte-identical across windows, so the device's flash is not
     rewritten on every transition.
 
-    Assumes the script is already installed and running via
-    ``async_start_scanner``. Raises RpcCallError if the script is not
-    installed on the device.
+    ``script_id`` must be the id returned by ``async_get_ble_script_id``
+    or otherwise known to the caller. This keeps each flip a single
+    Script.Eval round-trip with no Script.List overhead.
     """
-    script_name_to_id = await _async_get_scripts_by_name(device)
-    if (ble_script_id := script_name_to_id.get(BLE_SCRIPT_NAME)) is None:
-        raise RpcCallError(0, f"{BLE_SCRIPT_NAME} script not installed")
-    await device.script_eval(
-        ble_script_id, f"setActive({'true' if active else 'false'})"
-    )
+    await device.script_eval(script_id, f"setActive({'true' if active else 'false'})")
 
 
 def create_scanner(

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -56,7 +56,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
         if device is None or event_type is None or data_version is None:
             return False
         # Import here to avoid a circular import with aioshelly.ble.
-        from aioshelly import ble as _ble
+        from aioshelly import ble as _ble  # noqa: PLC0415
 
         async with self._active_window_lock:
             try:

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -49,13 +49,16 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
 
         Called by habluetooth's auto-mode scheduler. The Shelly BLE
         script is reprovisioned in active mode, then reverted to passive
-        once the window ends. Concurrent requests are serialized so the
-        device only sees one mode transition pair at a time.
+        once the window ends. Only one window may be open at a time; a
+        request that arrives while another window is in flight returns
+        ``False`` immediately so the caller can decide whether to retry.
         """
         device = self._active_window_device
         event_type = self._active_window_event_type
         data_version = self._active_window_data_version
         if device is None or event_type is None or data_version is None:
+            return False
+        if self._active_window_lock.locked():
             return False
 
         async with self._active_window_lock:
@@ -74,12 +77,17 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
             try:
                 await asyncio.sleep(duration)
             finally:
+                # Shield the restore so a cancellation mid-window still
+                # reverts the device to passive instead of leaving it
+                # burning battery in active mode.
                 try:
-                    await _ble.async_start_scanner(
-                        device,
-                        active=False,
-                        event_type=event_type,
-                        data_version=data_version,
+                    await asyncio.shield(
+                        _ble.async_start_scanner(
+                            device,
+                            active=False,
+                            event_type=event_type,
+                            data_version=data_version,
+                        )
                     )
                 except RpcCallError as err:
                     LOGGER.debug(

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -11,7 +11,7 @@ from habluetooth import BaseHaRemoteScanner
 
 from aioshelly import ble as _ble
 
-from ...exceptions import RpcCallError
+from ...exceptions import ShellyError
 from ..const import BLE_SCAN_RESULT_EVENT
 from ..parser import parse_ble_scan_result_event
 
@@ -69,7 +69,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                     event_type=event_type,
                     data_version=data_version,
                 )
-            except RpcCallError as err:
+            except ShellyError as err:
                 LOGGER.debug(
                     "%s: failed to enter active scan window: %s", self.name, err
                 )
@@ -89,7 +89,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                             data_version=data_version,
                         )
                     )
-                except RpcCallError as err:
+                except ShellyError as err:
                     # Restore failures leave the device stuck in active
                     # mode (drawing power, contradicting requested_mode
                     # in habluetooth) until the next successful window;

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -90,7 +90,12 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                         )
                     )
                 except RpcCallError as err:
-                    LOGGER.debug(
+                    # Restore failures leave the device stuck in active
+                    # mode (drawing power, contradicting requested_mode
+                    # in habluetooth) until the next successful window;
+                    # surface that at warning so operators can see it
+                    # without flipping the package to debug.
+                    LOGGER.warning(
                         "%s: failed to restore scan mode after active window: %s",
                         self.name,
                         err,

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -85,12 +85,13 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                 try:
                     await _ble.async_set_active_mode(device, script_id, active=False)
                 except ShellyError as err:
-                    # Restore failures leave the device in active mode
-                    # until the next successful window or integration
-                    # restart, which re-runs async_start_scanner and
-                    # re-bakes the initial passive default. Surface at
-                    # warning so operators can see it without flipping
-                    # the package to debug.
+                    # Restore failures almost always mean the WS to the
+                    # device dropped, in which case habluetooth's reload
+                    # cycle restarts the scanner anyway. Otherwise the
+                    # device stays in active mode until the next window's
+                    # restore succeeds or the device reboots; both are
+                    # acceptable for a battery safeguard. Surface at
+                    # warning so operators can still see it.
                     LOGGER.warning(
                         "%s: failed to restore scan mode after active window: %s",
                         self.name,

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -2,20 +2,92 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bluetooth_data_tools import monotonic_time_coarse
 from habluetooth import BaseHaRemoteScanner
 
+from ...exceptions import RpcCallError
 from ..const import BLE_SCAN_RESULT_EVENT
 from ..parser import parse_ble_scan_result_event
+
+if TYPE_CHECKING:
+    from ...rpc_device import RpcDevice
 
 LOGGER = logging.getLogger(__name__)
 
 
 class ShellyBLEScanner(BaseHaRemoteScanner):
     """Scanner for shelly."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the scanner."""
+        super().__init__(*args, **kwargs)
+        self._active_window_device: RpcDevice | None = None
+        self._active_window_event_type: str | None = None
+        self._active_window_data_version: int | None = None
+        self._active_window_lock = asyncio.Lock()
+
+    def set_active_window_provider(
+        self, device: RpcDevice, event_type: str, data_version: int
+    ) -> None:
+        """Bind the RpcDevice used to flip the BLE script for active windows.
+
+        Without this, async_request_active_window is a no-op returning
+        False (matching the BaseHaScanner default).
+        """
+        self._active_window_device = device
+        self._active_window_event_type = event_type
+        self._active_window_data_version = data_version
+
+    async def async_request_active_window(self, duration: float) -> bool:
+        """Flip the Shelly's BLE script to active for ``duration`` seconds.
+
+        Called by habluetooth's auto-mode scheduler. The Shelly BLE
+        script is reprovisioned in active mode, then reverted to passive
+        once the window ends. Concurrent requests are serialized so the
+        device only sees one mode transition pair at a time.
+        """
+        device = self._active_window_device
+        event_type = self._active_window_event_type
+        data_version = self._active_window_data_version
+        if device is None or event_type is None or data_version is None:
+            return False
+        # Import here to avoid a circular import with aioshelly.ble.
+        from aioshelly import ble as _ble
+
+        async with self._active_window_lock:
+            try:
+                await _ble.async_start_scanner(
+                    device,
+                    active=True,
+                    event_type=event_type,
+                    data_version=data_version,
+                )
+            except RpcCallError as err:
+                LOGGER.debug(
+                    "%s: failed to enter active scan window: %s", self.name, err
+                )
+                return False
+            try:
+                await asyncio.sleep(duration)
+            finally:
+                try:
+                    await _ble.async_start_scanner(
+                        device,
+                        active=False,
+                        event_type=event_type,
+                        data_version=data_version,
+                    )
+                except RpcCallError as err:
+                    LOGGER.debug(
+                        "%s: failed to restore scan mode after active window: %s",
+                        self.name,
+                        err,
+                    )
+        return True
 
     def async_on_event(self, event: dict[str, Any]) -> None:
         """Process an event from the shelly and ignore if its not a ble.scan_result."""

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 from bluetooth_data_tools import monotonic_time_coarse
 from habluetooth import BaseHaRemoteScanner
 
+from aioshelly import ble as _ble
+
 from ...exceptions import RpcCallError
 from ..const import BLE_SCAN_RESULT_EVENT
 from ..parser import parse_ble_scan_result_event
@@ -55,8 +57,6 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
         data_version = self._active_window_data_version
         if device is None or event_type is None or data_version is None:
             return False
-        # Import here to avoid a circular import with aioshelly.ble.
-        from aioshelly import ble as _ble  # noqa: PLC0415
 
         async with self._active_window_lock:
             try:

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -28,47 +28,35 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
         """Initialize the scanner."""
         super().__init__(*args, **kwargs)
         self._active_window_device: RpcDevice | None = None
-        self._active_window_event_type: str | None = None
-        self._active_window_data_version: int | None = None
         self._active_window_lock = asyncio.Lock()
 
-    def set_active_window_provider(
-        self, device: RpcDevice, event_type: str, data_version: int
-    ) -> None:
+    def set_active_window_provider(self, device: RpcDevice) -> None:
         """Bind the RpcDevice used to flip the BLE script for active windows.
 
         Without this, async_request_active_window is a no-op returning
         False (matching the BaseHaScanner default).
         """
         self._active_window_device = device
-        self._active_window_event_type = event_type
-        self._active_window_data_version = data_version
 
     async def async_request_active_window(self, duration: float) -> bool:
         """Flip the Shelly's BLE script to active for ``duration`` seconds.
 
         Called by habluetooth's auto-mode scheduler. The Shelly BLE
-        script is reprovisioned in active mode, then reverted to passive
-        once the window ends. Only one window may be open at a time; a
-        request that arrives while another window is in flight returns
-        ``False`` immediately so the caller can decide whether to retry.
+        script's scanner is flipped to active mode via Script.Eval,
+        then reverted to passive once the window ends. Only one window
+        may be open at a time; a request that arrives while another
+        window is in flight returns ``False`` immediately so the
+        caller can decide whether to retry.
         """
         device = self._active_window_device
-        event_type = self._active_window_event_type
-        data_version = self._active_window_data_version
-        if device is None or event_type is None or data_version is None:
+        if device is None:
             return False
         if self._active_window_lock.locked():
             return False
 
         async with self._active_window_lock:
             try:
-                await _ble.async_start_scanner(
-                    device,
-                    active=True,
-                    event_type=event_type,
-                    data_version=data_version,
-                )
+                await _ble.async_set_active_mode(device, active=True)
             except ShellyError as err:
                 LOGGER.debug(
                     "%s: failed to enter active scan window: %s", self.name, err
@@ -82,12 +70,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                 # burning battery in active mode.
                 try:
                     await asyncio.shield(
-                        _ble.async_start_scanner(
-                            device,
-                            active=False,
-                            event_type=event_type,
-                            data_version=data_version,
-                        )
+                        _ble.async_set_active_mode(device, active=False)
                     )
                 except ShellyError as err:
                     # Restore failures leave the device stuck in active

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -28,6 +28,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
         """Initialize the scanner."""
         super().__init__(*args, **kwargs)
         self._active_window_device: RpcDevice | None = None
+        self._active_window_script_id: int | None = None
         self._active_window_lock = asyncio.Lock()
 
     def set_active_window_provider(self, device: RpcDevice) -> None:
@@ -55,8 +56,24 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
             return False
 
         async with self._active_window_lock:
+            script_id = self._active_window_script_id
+            if script_id is None:
+                try:
+                    script_id = await _ble.async_get_ble_script_id(device)
+                except ShellyError as err:
+                    LOGGER.debug(
+                        "%s: failed to resolve BLE script id: %s", self.name, err
+                    )
+                    return False
+                if script_id is None:
+                    LOGGER.debug(
+                        "%s: BLE script not installed, skipping active window",
+                        self.name,
+                    )
+                    return False
+                self._active_window_script_id = script_id
             try:
-                await _ble.async_set_active_mode(device, active=True)
+                await _ble.async_set_active_mode(device, script_id, active=True)
             except ShellyError as err:
                 LOGGER.debug(
                     "%s: failed to enter active scan window: %s", self.name, err
@@ -65,19 +82,15 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
             try:
                 await asyncio.sleep(duration)
             finally:
-                # Shield the restore so a cancellation mid-window still
-                # reverts the device to passive instead of leaving it
-                # burning battery in active mode.
                 try:
-                    await asyncio.shield(
-                        _ble.async_set_active_mode(device, active=False)
-                    )
+                    await _ble.async_set_active_mode(device, script_id, active=False)
                 except ShellyError as err:
-                    # Restore failures leave the device stuck in active
-                    # mode (drawing power, contradicting requested_mode
-                    # in habluetooth) until the next successful window;
-                    # surface that at warning so operators can see it
-                    # without flipping the package to debug.
+                    # Restore failures leave the device in active mode
+                    # until the next successful window or integration
+                    # restart, which re-runs async_start_scanner and
+                    # re-bakes the initial passive default. Surface at
+                    # warning so operators can see it without flipping
+                    # the package to debug.
                     LOGGER.warning(
                         "%s: failed to restore scan mode after active window: %s",
                         self.name,

--- a/aioshelly/ble/const.py
+++ b/aioshelly/ble/const.py
@@ -13,7 +13,7 @@ VAR_ACTIVE = "%active%"
 VAR_VERSION = "%version%"
 
 BLE_CODE = """
-// aioshelly BLE script 2.0
+// aioshelly BLE script 2.1
 // Script automatically installed by Home Assistant for Bluetooth proxy support
 // https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies
 const queueServeTimer = 100; // in ms, timer for events emitting
@@ -66,13 +66,40 @@ function bleCallback(event, res) {
   }
 }
 
-// Skip starting if scanner is active
-if (!BLE.Scanner.isRunning()) {
+// Flip the scanner's active mode at runtime via Script.Eval; this is
+// how on-demand active scan windows avoid rewriting the script body
+// (and thus avoid a flash write) on every transition.
+//
+// Two device quirks shape this dance:
+//   1. BLE.Scanner.Stop() is asynchronous - a Start() issued in the
+//      same JS frame races with the still-in-progress stop and
+//      silently fails. Defer Start onto a Timer so the underlying BLE
+//      stack has time to settle.
+//   2. BLE.Scanner.Subscribe() does NOT survive a Stop/Start cycle -
+//      the subscription is dropped on Stop and must be re-attached
+//      after each Start, or no scan results will be delivered.
+let pendingActive = null;
+function applyPendingActive() {
+  if (pendingActive === null) {
+    return;
+  }
   BLE.Scanner.Start({
     duration_ms: -1,
-    active: %active%,
+    active: pendingActive,
   });
+  BLE.Scanner.Subscribe(bleCallback);
+  pendingActive = null;
 }
 
-BLE.Scanner.Subscribe(bleCallback);
+function setActive(v) {
+  pendingActive = v;
+  if (BLE.Scanner.isRunning()) {
+    BLE.Scanner.Stop();
+    Timer.set(250, false, applyPendingActive);
+  } else {
+    applyPendingActive();
+  }
+}
+
+setActive(%active%);
 """  # noqa: E501

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -763,6 +763,10 @@ class RpcDevice:
         """Stop a script using 'Script.Stop'."""
         await self.call_rpc("Script.Stop", {"id": script_id})
 
+    async def script_eval(self, script_id: int, code: str) -> Any:
+        """Evaluate code in a running script using 'Script.Eval'."""
+        return await self.call_rpc("Script.Eval", {"id": script_id, "code": code})
+
     async def ble_setconfig(self, enable: bool, enable_rpc: bool) -> ShellyBLESetConfig:
         """Enable or disable ble with BLE.SetConfig."""
         return cast(

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -48,6 +48,22 @@ def _bind(scanner: object) -> AsyncMock:
 
 
 @pytest.mark.asyncio
+async def test_async_request_active_window_resolve_failure_returns_false() -> None:
+    """A ShellyError while resolving the script id yields False without flipping."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    _bind(scanner)
+    with (
+        patch(
+            "aioshelly.ble.async_get_ble_script_id",
+            AsyncMock(side_effect=RpcCallError(500, "list failed")),
+        ),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set,
+    ):
+        assert await scanner.async_request_active_window(0.0) is False
+    mock_set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_async_request_active_window_no_script() -> None:
     """If the integration script isn't installed, return False without flipping."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from aioshelly.ble import create_scanner
+from aioshelly.exceptions import RpcCallError
 
 
 @pytest.mark.asyncio
@@ -28,3 +31,53 @@ async def test_create_scanner_back_compat() -> None:
     ble_device, advertisement_data = scanner_data["AA:BB:CC:DD:EE:FF"]
     assert advertisement_data.rssi == -50
     assert ble_device.address == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_no_provider() -> None:
+    """Without a bound device the request returns False without any RPC traffic."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    assert await scanner.async_request_active_window(0.0) is False
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_flips_then_restores() -> None:
+    """The Shelly is reprovisioned active then reverted to passive."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    with patch("aioshelly.ble.async_start_scanner", AsyncMock()) as mock_start:
+        assert await scanner.async_request_active_window(0.0) is True
+    actives = [call.kwargs["active"] for call in mock_start.await_args_list]
+    assert actives == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_entry_failure_returns_false() -> None:
+    """A failure on the entry call yields False; no restore is attempted."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    mock_start = AsyncMock(side_effect=RpcCallError(500, "boom"))
+    with patch("aioshelly.ble.async_start_scanner", mock_start):
+        assert await scanner.async_request_active_window(0.0) is False
+    assert mock_start.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_failure_swallowed() -> None:
+    """If the restore call fails the window still reports success."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    call_count = 0
+
+    async def fake_start(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RpcCallError(500, "restore failed")
+
+    with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
+        assert await scanner.async_request_active_window(0.0) is True
+    assert call_count == 2

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -46,10 +46,10 @@ async def test_async_request_active_window_flips_then_restores() -> None:
     """The Shelly is reprovisioned active then reverted to passive."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
-    with patch("aioshelly.ble.async_start_scanner", AsyncMock()) as mock_start:
+    scanner.set_active_window_provider(device)
+    with patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set:
         assert await scanner.async_request_active_window(0.0) is True
-    actives = [call.kwargs["active"] for call in mock_start.await_args_list]
+    actives = [call.kwargs["active"] for call in mock_set.await_args_list]
     assert actives == [True, False]
 
 
@@ -58,11 +58,11 @@ async def test_async_request_active_window_entry_failure_returns_false() -> None
     """A failure on the entry call yields False; no restore is attempted."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
-    mock_start = AsyncMock(side_effect=RpcCallError(500, "boom"))
-    with patch("aioshelly.ble.async_start_scanner", mock_start):
+    scanner.set_active_window_provider(device)
+    mock_set = AsyncMock(side_effect=RpcCallError(500, "boom"))
+    with patch("aioshelly.ble.async_set_active_mode", mock_set):
         assert await scanner.async_request_active_window(0.0) is False
-    assert mock_start.await_count == 1
+    assert mock_set.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -70,16 +70,16 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
     """If the restore call fails the window still reports success."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    scanner.set_active_window_provider(device)
     call_count = 0
 
-    async def fake_start(*_args: object, **_kwargs: object) -> None:
+    async def fake_set(*_args: object, **_kwargs: object) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 2:
             raise RpcCallError(500, "restore failed")
 
-    with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
+    with patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)):
         assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
 
@@ -89,11 +89,11 @@ async def test_async_request_active_window_entry_device_error_returns_false() ->
     """A DeviceConnectionError on entry yields False; the contract is bool-only."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
-    mock_start = AsyncMock(side_effect=DeviceConnectionError("disconnected"))
-    with patch("aioshelly.ble.async_start_scanner", mock_start):
+    scanner.set_active_window_provider(device)
+    mock_set = AsyncMock(side_effect=DeviceConnectionError("disconnected"))
+    with patch("aioshelly.ble.async_set_active_mode", mock_set):
         assert await scanner.async_request_active_window(0.0) is False
-    assert mock_start.await_count == 1
+    assert mock_set.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -101,16 +101,16 @@ async def test_async_request_active_window_restore_device_error_swallowed() -> N
     """A DeviceConnectionError on restore is swallowed, window still reports True."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    scanner.set_active_window_provider(device)
     call_count = 0
 
-    async def fake_start(*_args: object, **_kwargs: object) -> None:
+    async def fake_set(*_args: object, **_kwargs: object) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 2:
             raise DeviceConnectionError("disconnected mid-window")
 
-    with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
+    with patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)):
         assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
 
@@ -120,22 +120,22 @@ async def test_async_request_active_window_rejects_overlap() -> None:
     """A second request while a window is open returns False without flipping."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    scanner.set_active_window_provider(device)
     gate = asyncio.Event()
 
-    async def fake_start(*_args: object, **kwargs: object) -> None:
+    async def fake_set(*_args: object, **kwargs: object) -> None:
         if kwargs.get("active"):
             await gate.wait()
 
     with patch(
-        "aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)
-    ) as mock_start:
+        "aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)
+    ) as mock_set:
         first = asyncio.create_task(scanner.async_request_active_window(0.0))
         # Yield so the first task acquires the lock and blocks inside the entry call.
         await asyncio.sleep(0)
         assert await scanner.async_request_active_window(0.0) is False
-        # Only the first task has called async_start_scanner (the entry flip).
-        assert mock_start.await_count == 1
+        # Only the first task has called async_set_active_mode (the entry flip).
+        assert mock_set.await_count == 1
         gate.set()
         assert await first is True
 
@@ -145,9 +145,9 @@ async def test_async_request_active_window_restore_runs_under_cancellation() -> 
     """Cancelling the task during the window still fires the restore call."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
     device = AsyncMock()
-    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    scanner.set_active_window_provider(device)
 
-    with patch("aioshelly.ble.async_start_scanner", AsyncMock()) as mock_start:
+    with patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set:
         task = asyncio.create_task(scanner.async_request_active_window(3600.0))
         # Let the entry call complete and the task enter the sleep.
         await asyncio.sleep(0)
@@ -155,5 +155,5 @@ async def test_async_request_active_window_restore_runs_under_cancellation() -> 
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-    actives = [call.kwargs["active"] for call in mock_start.await_args_list]
+    actives = [call.kwargs["active"] for call in mock_set.await_args_list]
     assert actives == [True, False]

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -85,6 +85,40 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
 
 
 @pytest.mark.asyncio
+<<<<<<< Updated upstream
+=======
+async def test_async_request_active_window_entry_device_error_returns_false() -> None:
+    """A DeviceConnectionError on entry yields False; the contract is bool-only."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    mock_start = AsyncMock(side_effect=DeviceConnectionError("disconnected"))
+    with patch("aioshelly.ble.async_start_scanner", mock_start):
+        assert await scanner.async_request_active_window(0.0) is False
+    assert mock_start.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_device_error_swallowed() -> None:
+    """A DeviceConnectionError on restore is swallowed, window still reports True."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    call_count = 0
+
+    async def fake_start(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise DeviceConnectionError("disconnected mid-window")
+
+    with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
+        assert await scanner.async_request_active_window(0.0) is True
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+>>>>>>> Stashed changes
 async def test_async_request_active_window_rejects_overlap() -> None:
     """A second request while a window is open returns False without flipping."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aioshelly.ble import create_scanner
-from aioshelly.exceptions import RpcCallError
+from aioshelly.exceptions import DeviceConnectionError, RpcCallError
 
 
 @pytest.mark.asyncio
@@ -78,6 +78,37 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
         call_count += 1
         if call_count == 2:
             raise RpcCallError(500, "restore failed")
+
+    with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
+        assert await scanner.async_request_active_window(0.0) is True
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_entry_device_error_returns_false() -> None:
+    """A DeviceConnectionError on entry yields False; the contract is bool-only."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    mock_start = AsyncMock(side_effect=DeviceConnectionError("disconnected"))
+    with patch("aioshelly.ble.async_start_scanner", mock_start):
+        assert await scanner.async_request_active_window(0.0) is False
+    assert mock_start.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_device_error_swallowed() -> None:
+    """A DeviceConnectionError on restore is swallowed; the window still reports True."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    call_count = 0
+
+    async def fake_start(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise DeviceConnectionError("disconnected mid-window")
 
     with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
         assert await scanner.async_request_active_window(0.0) is True

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -41,26 +41,68 @@ async def test_async_request_active_window_no_provider() -> None:
     assert await scanner.async_request_active_window(0.0) is False
 
 
+def _bind(scanner: object) -> AsyncMock:
+    device = AsyncMock()
+    scanner.set_active_window_provider(device)  # type: ignore[attr-defined]
+    return device
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_no_script() -> None:
+    """If the integration script isn't installed, return False without flipping."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    _bind(scanner)
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=None)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set,
+    ):
+        assert await scanner.async_request_active_window(0.0) is False
+    mock_set.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_async_request_active_window_flips_then_restores() -> None:
-    """The Shelly is reprovisioned active then reverted to passive."""
+    """The Shelly is flipped active then reverted to passive."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
-    with patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set:
+    _bind(scanner)
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set,
+    ):
         assert await scanner.async_request_active_window(0.0) is True
     actives = [call.kwargs["active"] for call in mock_set.await_args_list]
     assert actives == [True, False]
+    # script_id is passed positionally as the second arg.
+    script_ids = [call.args[1] for call in mock_set.await_args_list]
+    assert script_ids == [7, 7]
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_caches_script_id() -> None:
+    """Across two windows the script id is resolved exactly once."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    _bind(scanner)
+    with (
+        patch(
+            "aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)
+        ) as mock_get,
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock()),
+    ):
+        assert await scanner.async_request_active_window(0.0) is True
+        assert await scanner.async_request_active_window(0.0) is True
+    assert mock_get.await_count == 1
 
 
 @pytest.mark.asyncio
 async def test_async_request_active_window_entry_failure_returns_false() -> None:
     """A failure on the entry call yields False; no restore is attempted."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
     mock_set = AsyncMock(side_effect=RpcCallError(500, "boom"))
-    with patch("aioshelly.ble.async_set_active_mode", mock_set):
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", mock_set),
+    ):
         assert await scanner.async_request_active_window(0.0) is False
     assert mock_set.await_count == 1
 
@@ -69,8 +111,7 @@ async def test_async_request_active_window_entry_failure_returns_false() -> None
 async def test_async_request_active_window_restore_failure_swallowed() -> None:
     """If the restore call fails the window still reports success."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
     call_count = 0
 
     async def fake_set(*_args: object, **_kwargs: object) -> None:
@@ -79,7 +120,10 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
         if call_count == 2:
             raise RpcCallError(500, "restore failed")
 
-    with patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)):
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)),
+    ):
         assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
 
@@ -88,10 +132,12 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
 async def test_async_request_active_window_entry_device_error_returns_false() -> None:
     """A DeviceConnectionError on entry yields False; the contract is bool-only."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
     mock_set = AsyncMock(side_effect=DeviceConnectionError("disconnected"))
-    with patch("aioshelly.ble.async_set_active_mode", mock_set):
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", mock_set),
+    ):
         assert await scanner.async_request_active_window(0.0) is False
     assert mock_set.await_count == 1
 
@@ -100,8 +146,7 @@ async def test_async_request_active_window_entry_device_error_returns_false() ->
 async def test_async_request_active_window_restore_device_error_swallowed() -> None:
     """A DeviceConnectionError on restore is swallowed, window still reports True."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
     call_count = 0
 
     async def fake_set(*_args: object, **_kwargs: object) -> None:
@@ -110,7 +155,10 @@ async def test_async_request_active_window_restore_device_error_swallowed() -> N
         if call_count == 2:
             raise DeviceConnectionError("disconnected mid-window")
 
-    with patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)):
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)),
+    ):
         assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
 
@@ -119,17 +167,19 @@ async def test_async_request_active_window_restore_device_error_swallowed() -> N
 async def test_async_request_active_window_rejects_overlap() -> None:
     """A second request while a window is open returns False without flipping."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
     gate = asyncio.Event()
 
     async def fake_set(*_args: object, **kwargs: object) -> None:
         if kwargs.get("active"):
             await gate.wait()
 
-    with patch(
-        "aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)
-    ) as mock_set:
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch(
+            "aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)
+        ) as mock_set,
+    ):
         first = asyncio.create_task(scanner.async_request_active_window(0.0))
         # Yield so the first task acquires the lock and blocks inside the entry call.
         await asyncio.sleep(0)
@@ -144,10 +194,12 @@ async def test_async_request_active_window_rejects_overlap() -> None:
 async def test_async_request_active_window_restore_runs_under_cancellation() -> None:
     """Cancelling the task during the window still fires the restore call."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
-    device = AsyncMock()
-    scanner.set_active_window_provider(device)
+    _bind(scanner)
 
-    with patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set:
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock()) as mock_set,
+    ):
         task = asyncio.create_task(scanner.async_request_active_window(3600.0))
         # Let the entry call complete and the task enter the sleep.
         await asyncio.sleep(0)

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -81,3 +82,47 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
     with patch("aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)):
         assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_rejects_overlap() -> None:
+    """A second request while a window is open returns False without flipping."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+    gate = asyncio.Event()
+
+    async def fake_start(*_args: object, **kwargs: object) -> None:
+        if kwargs.get("active"):
+            await gate.wait()
+
+    with patch(
+        "aioshelly.ble.async_start_scanner", AsyncMock(side_effect=fake_start)
+    ) as mock_start:
+        first = asyncio.create_task(scanner.async_request_active_window(0.0))
+        # Yield so the first task acquires the lock and blocks inside the entry call.
+        await asyncio.sleep(0)
+        assert await scanner.async_request_active_window(0.0) is False
+        # Only the first task has called async_start_scanner (the entry flip).
+        assert mock_start.await_count == 1
+        gate.set()
+        assert await first is True
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_runs_under_cancellation() -> None:
+    """Cancelling the task during the window still fires the restore call."""
+    scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
+    device = AsyncMock()
+    scanner.set_active_window_provider(device, "ble.scan_result", 2)
+
+    with patch("aioshelly.ble.async_start_scanner", AsyncMock()) as mock_start:
+        task = asyncio.create_task(scanner.async_request_active_window(3600.0))
+        # Let the entry call complete and the task enter the sleep.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    actives = [call.kwargs["active"] for call in mock_start.await_args_list]
+    assert actives == [True, False]

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -85,8 +85,6 @@ async def test_async_request_active_window_restore_failure_swallowed() -> None:
 
 
 @pytest.mark.asyncio
-<<<<<<< Updated upstream
-=======
 async def test_async_request_active_window_entry_device_error_returns_false() -> None:
     """A DeviceConnectionError on entry yields False; the contract is bool-only."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")
@@ -118,7 +116,6 @@ async def test_async_request_active_window_restore_device_error_swallowed() -> N
 
 
 @pytest.mark.asyncio
->>>>>>> Stashed changes
 async def test_async_request_active_window_rejects_overlap() -> None:
     """A second request while a window is open returns False without flipping."""
     scanner = create_scanner("AA:BB:CC:DD:EE:FF", "shelly")

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -11,11 +11,13 @@ from habluetooth import BluetoothScanningMode
 
 from aioshelly.ble import (
     async_ensure_ble_enabled,
+    async_set_active_mode,
     create_scanner,
     get_device_from_model_id,
     get_name_from_model_id,
 )
 from aioshelly.const import DEVICES
+from aioshelly.exceptions import RpcCallError
 
 
 @pytest.mark.asyncio
@@ -123,6 +125,36 @@ def test_get_name_from_model_id() -> None:
     # Test with invalid model ID
     name = get_name_from_model_id(0x9999)
     assert name is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active", "expected_code"),
+    [
+        (True, "setActive(true)"),
+        (False, "setActive(false)"),
+    ],
+)
+async def test_async_set_active_mode(active: bool, expected_code: str) -> None:
+    """Script.Eval is called with the right setActive expression."""
+    device = AsyncMock()
+    device.script_list = AsyncMock(
+        return_value=[{"name": "aioshelly_ble_integration", "id": 7}]
+    )
+    device.script_eval = AsyncMock()
+    await async_set_active_mode(device, active=active)
+    device.script_eval.assert_awaited_once_with(7, expected_code)
+
+
+@pytest.mark.asyncio
+async def test_async_set_active_mode_missing_script() -> None:
+    """If the script is not installed the helper raises RpcCallError."""
+    device = AsyncMock()
+    device.script_list = AsyncMock(return_value=[{"name": "other_script", "id": 1}])
+    device.script_eval = AsyncMock()
+    with pytest.raises(RpcCallError):
+        await async_set_active_mode(device, active=True)
+    device.script_eval.assert_not_awaited()
 
 
 def test_duplicate_model_ids() -> None:

--- a/tests/ble/test_init.py
+++ b/tests/ble/test_init.py
@@ -11,13 +11,13 @@ from habluetooth import BluetoothScanningMode
 
 from aioshelly.ble import (
     async_ensure_ble_enabled,
+    async_get_ble_script_id,
     async_set_active_mode,
     create_scanner,
     get_device_from_model_id,
     get_name_from_model_id,
 )
 from aioshelly.const import DEVICES
-from aioshelly.exceptions import RpcCallError
 
 
 @pytest.mark.asyncio
@@ -128,6 +128,27 @@ def test_get_name_from_model_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_get_ble_script_id_found() -> None:
+    """The integration script id is resolved by name."""
+    device = AsyncMock()
+    device.script_list = AsyncMock(
+        return_value=[
+            {"name": "other", "id": 1},
+            {"name": "aioshelly_ble_integration", "id": 7},
+        ]
+    )
+    assert await async_get_ble_script_id(device) == 7
+
+
+@pytest.mark.asyncio
+async def test_async_get_ble_script_id_missing() -> None:
+    """If no integration script is installed the helper returns None."""
+    device = AsyncMock()
+    device.script_list = AsyncMock(return_value=[{"name": "other", "id": 1}])
+    assert await async_get_ble_script_id(device) is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("active", "expected_code"),
     [
@@ -138,23 +159,9 @@ def test_get_name_from_model_id() -> None:
 async def test_async_set_active_mode(active: bool, expected_code: str) -> None:
     """Script.Eval is called with the right setActive expression."""
     device = AsyncMock()
-    device.script_list = AsyncMock(
-        return_value=[{"name": "aioshelly_ble_integration", "id": 7}]
-    )
     device.script_eval = AsyncMock()
-    await async_set_active_mode(device, active=active)
+    await async_set_active_mode(device, 7, active=active)
     device.script_eval.assert_awaited_once_with(7, expected_code)
-
-
-@pytest.mark.asyncio
-async def test_async_set_active_mode_missing_script() -> None:
-    """If the script is not installed the helper raises RpcCallError."""
-    device = AsyncMock()
-    device.script_list = AsyncMock(return_value=[{"name": "other_script", "id": 1}])
-    device.script_eval = AsyncMock()
-    with pytest.raises(RpcCallError):
-        await async_set_active_mode(device, active=True)
-    device.script_eval.assert_not_awaited()
 
 
 def test_duplicate_model_ids() -> None:

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -706,6 +706,19 @@ async def test_script_create(rpc_device: RpcDevice) -> None:
 
 
 @pytest.mark.asyncio
+async def test_script_eval(rpc_device: RpcDevice) -> None:
+    """Test RpcDevice script_eval method."""
+    await rpc_device.script_eval(7, "setActive(true)")
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][0] == "Script.Eval"
+    assert rpc_device.call_rpc_multiple.call_args[0][0][0][1] == {
+        "id": 7,
+        "code": "setActive(true)",
+    }
+
+
+@pytest.mark.asyncio
 async def test_script_putcode(rpc_device: RpcDevice) -> None:
     """Test RpcDevice script_putcode method."""
     await rpc_device.script_putcode(9, "lorem ipsum")


### PR DESCRIPTION
Pairs with Bluetooth-Devices/habluetooth#448 and home-assistant/core#172008. habluetooth gained a per-device active-scan scheduler that flips AUTO-mode scanners into active for a short window on demand; for that to work on Shelly proxies the ShellyBLEScanner needs to know how to flip its BLE script's scan mode.

## Behavior

`ShellyBLEScanner.async_request_active_window` flips the device's BLE scanner to active via `Script.Eval`, sleeps for the requested duration, then flips it back to passive. Callers wire the `RpcDevice` via `set_active_window_provider(device)`; without that the override returns `False` so it matches the no-op default on `BaseHaScanner` and existing setups keep working unchanged. A per-scanner `asyncio.Lock` serializes overlapping requests so the device only ever sees one mode transition pair at a time, `ShellyError` during entry or restore is logged and swallowed, and the scanner caches the BLE script id after the first window so every subsequent flip is just one Script.Eval round-trip.

## Why Script.Eval instead of re-flashing

The first cut re-ran `async_start_scanner` per window, which re-templated the body with the new `active=true|false` literal, detected the body diff, and issued `Script.PutCode` (a flash write) twice per window. For a power feature with potentially frequent windows that's noticeable flash wear. The BLE script now exposes a `setActive(v)` JS function, and the new `async_set_active_mode` helper drives it through `Script.Eval`. Window flips touch zero flash and the steady state is exactly two `Script.Eval` calls per window.

Two Shelly Script API quirks shape the JS side:
1. `BLE.Scanner.Stop()` is asynchronous, so a `Start()` in the same JS frame races with the still-in-progress stop and silently fails. `setActive` defers the `Start` via `Timer.set(250, ...)`.
2. `BLE.Scanner.Subscribe()` does not survive a Stop/Start cycle, so it is re-attached inside `applyPendingActive` after every `Start`.

Script header bumped to 2.1; existing devices migrate once on the next `async_start_scanner` (one putcode), then run flash-free for every window thereafter.

## Hardware verification

Tested on Shelly Plug US (SNPL-00116US, fw 1.7.5):
- One-time 2.0 to 2.1 migration: exactly one `Script.PutCode`
- Per window: exactly 2 `Script.Eval`, zero `PutCode`/`Start`/`Stop`
- Script id resolved exactly once across multiple windows on the same scanner
- Script body byte-identical across consecutive windows
- Active-mode actually flips: a background subscriber capturing `ble.scan_result` events to a JSONL file shows `scan_rsp` populated for ~40-50% of advertisements during active windows and ~5-10% during passive (residue is queue spill from samples emitted just after the flip)

## Status

Draft because it depends on habluetooth 6.3.0, which is not released yet.