### PR TITLE
Bump astral-sh/setup-uv to 8.1.0

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           activate-environment: true


### PR DESCRIPTION
Since version `8.0.0` `setup-uv` doesn't provide `@vX` version tag. It is recommended to use githash instead of version tag.

Ref: https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0

<img width="891" height="238" alt="obraz" src="https://github.com/user-attachments/assets/12650045-62a4-4aab-af59-ddf85d9c8ffa" />

`dependabot` supports updating dependencies with a pinned hash.
