### PR TITLE
Reflect active scan windows in ShellyBLEScanner.current_mode

### DIFF
--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -85,21 +85,31 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                 await asyncio.sleep(duration)
             finally:
                 try:
-                    await _ble.async_set_active_mode(device, script_id, active=False)
-                except ShellyError as err:
-                    # Restore failures almost always mean the WS to the
-                    # device dropped, in which case habluetooth's reload
-                    # cycle restarts the scanner anyway. Otherwise the
-                    # device stays in active mode until the next window's
-                    # restore succeeds or the device reboots; both are
-                    # acceptable for a battery safeguard. Surface at
-                    # warning so operators can still see it.
-                    LOGGER.warning(
-                        "%s: failed to restore scan mode after active window: %s",
-                        self.name,
-                        err,
-                    )
-                self.set_current_mode(previous_mode)  # ty: ignore[unresolved-attribute]
+                    try:
+                        await _ble.async_set_active_mode(
+                            device, script_id, active=False
+                        )
+                    except ShellyError as err:
+                        # Restore failures almost always mean the WS to the
+                        # device dropped, in which case habluetooth's reload
+                        # cycle restarts the scanner anyway. Otherwise the
+                        # device stays in active mode until the next window's
+                        # restore succeeds or the device reboots; both are
+                        # acceptable for a battery safeguard. Surface at
+                        # warning so operators can still see it.
+                        LOGGER.warning(
+                            "%s: failed to restore scan mode after active window: %s",
+                            self.name,
+                            err,
+                        )
+                finally:
+                    # Always reflect that the window has ended, even if the
+                    # restore RPC was cancelled or raised an unexpected error.
+                    # The device may still be sweeping actively, but
+                    # habluetooth's reload cycle reconciles on the next
+                    # scanner start, and leaving current_mode stuck at ACTIVE
+                    # would mislead the manager and UI indefinitely.
+                    self.set_current_mode(previous_mode)  # ty: ignore[unresolved-attribute]
         return True
 
     def async_on_event(self, event: dict[str, Any]) -> None:

--- a/aioshelly/ble/backend/scanner.py
+++ b/aioshelly/ble/backend/scanner.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from bluetooth_data_tools import monotonic_time_coarse
-from habluetooth import BaseHaRemoteScanner
+from habluetooth import BaseHaRemoteScanner, BluetoothScanningMode
 
 from aioshelly import ble as _ble
 
@@ -79,6 +79,8 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                     "%s: failed to enter active scan window: %s", self.name, err
                 )
                 return False
+            previous_mode = self.current_mode
+            self.set_current_mode(BluetoothScanningMode.ACTIVE)  # ty: ignore[unresolved-attribute]
             try:
                 await asyncio.sleep(duration)
             finally:
@@ -97,6 +99,7 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
                         self.name,
                         err,
                     )
+                self.set_current_mode(previous_mode)  # ty: ignore[unresolved-attribute]
         return True
 
     def async_on_event(self, event: dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "aiohttp>=3.11.1",
   "bleak-retry-connector>=3.0.0",
   "bluetooth-data-tools>=1.28.0",
-  "habluetooth>=3.42.0",
+  "habluetooth>=5.10.0",
   "orjson>=3.11.6",
   "yarl",
   "zeroconf>=0.148.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "aiohttp>=3.11.1",
   "bleak-retry-connector>=3.0.0",
   "bluetooth-data-tools>=1.28.0",
-  "habluetooth>=5.10.0",
+  "habluetooth>=6.3.0",
   "orjson>=3.11.6",
   "yarl",
   "zeroconf>=0.148.0"

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -283,3 +283,34 @@ async def test_async_request_active_window_restore_runs_under_cancellation() -> 
             await task
     actives = [call.kwargs["active"] for call in mock_set.await_args_list]
     assert actives == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_active_window_restores_current_mode_when_restore_is_cancelled() -> None:
+    """Cancellation mid-restore still flips current_mode back to the prior value."""
+    scanner = create_scanner(
+        "AA:BB:CC:DD:EE:FF",
+        "shelly",
+        requested_mode=BluetoothScanningMode.PASSIVE,
+        current_mode=BluetoothScanningMode.PASSIVE,
+    )
+    _bind(scanner)
+    restore_started = asyncio.Event()
+
+    async def fake_set(*_args: object, **kwargs: object) -> None:
+        if not kwargs.get("active"):
+            restore_started.set()
+            await asyncio.sleep(3600)
+
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)),
+    ):
+        task = asyncio.create_task(scanner.async_request_active_window(0.0))
+        await restore_started.wait()
+        # Window is past entry; the restore RPC is in flight.
+        assert scanner.current_mode is BluetoothScanningMode.ACTIVE
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert scanner.current_mode is BluetoothScanningMode.PASSIVE

--- a/tests/ble/backend/test_scanner.py
+++ b/tests/ble/backend/test_scanner.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from habluetooth import BluetoothScanningMode
 
 from aioshelly.ble import create_scanner
 from aioshelly.exceptions import DeviceConnectionError, RpcCallError
@@ -204,6 +205,63 @@ async def test_async_request_active_window_rejects_overlap() -> None:
         assert mock_set.await_count == 1
         gate.set()
         assert await first is True
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_updates_current_mode() -> None:
+    """During a window current_mode flips to ACTIVE then back to the prior value.
+
+    The UI reads current_mode (via the manager's scanner_mode_changed
+    notification), so without this the proxy keeps reporting passive
+    while the Shelly is actually doing active sweeps.
+    """
+    scanner = create_scanner(
+        "AA:BB:CC:DD:EE:FF",
+        "shelly",
+        requested_mode=BluetoothScanningMode.PASSIVE,
+        current_mode=BluetoothScanningMode.PASSIVE,
+    )
+    _bind(scanner)
+    observed: list[BluetoothScanningMode | None] = []
+
+    async def fake_set(*_args: object, **_kwargs: object) -> None:
+        observed.append(scanner.current_mode)
+
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)),
+    ):
+        assert await scanner.async_request_active_window(0.0) is True
+    # Entry RPC ran before the flip (pre-flip mode); restore RPC ran while
+    # the window was open (so current_mode was ACTIVE at that point).
+    assert observed == [BluetoothScanningMode.PASSIVE, BluetoothScanningMode.ACTIVE]
+    assert scanner.current_mode is BluetoothScanningMode.PASSIVE
+
+
+@pytest.mark.asyncio
+async def test_active_window_restores_current_mode_on_restore_failure() -> None:
+    """A failed restore still flips current_mode back so the UI doesn't lie forever."""
+    scanner = create_scanner(
+        "AA:BB:CC:DD:EE:FF",
+        "shelly",
+        requested_mode=BluetoothScanningMode.PASSIVE,
+        current_mode=BluetoothScanningMode.PASSIVE,
+    )
+    _bind(scanner)
+    call_count = 0
+
+    async def fake_set(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RpcCallError(500, "restore failed")
+
+    with (
+        patch("aioshelly.ble.async_get_ble_script_id", AsyncMock(return_value=7)),
+        patch("aioshelly.ble.async_set_active_mode", AsyncMock(side_effect=fake_set)),
+    ):
+        assert await scanner.async_request_active_window(0.0) is True
+    assert scanner.current_mode is BluetoothScanningMode.PASSIVE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When the auto scheduler flips a Shelly proxy into an active scan window the device gets the right `Script.Eval`, but `self.current_mode` is never updated, so the manager is never notified and the UI keeps showing the proxy as passive even while it is sweeping actively.

The override now calls `set_current_mode(ACTIVE)` after the entry flip succeeds and restores the prior value in the finally block, matching how the local `HaScanner` tracks its own window; `requested_mode` is untouched, only `current_mode` reflects the live state.

Bumps habluetooth to >=6.3.0