### PR TITLE
Avoid double-decoding RPC WebSocket frames with aiohttp decode_text

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -13,7 +13,7 @@ from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from enum import Enum, auto
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from aiohttp import (
     ClientSession,
@@ -22,6 +22,7 @@ from aiohttp import (
     WSMsgType,
     client_exceptions,
 )
+from aiohttp.http_websocket import WSMessageTextBytes
 from aiohttp.web import (
     Application,
     AppRunner,
@@ -60,7 +61,7 @@ class RPCSource(Enum):
     SERVER = auto()
 
 
-def _receive_json_or_raise(msg: WSMessage) -> dict[str, Any]:
+def _receive_json_or_raise(msg: WSMessage | WSMessageTextBytes) -> dict[str, Any]:
     """Receive json or raise."""
     if msg.type is WSMsgType.TEXT:
         try:
@@ -240,7 +241,7 @@ class WsRPC(WsBase):
         self._port = port
         self._on_notification = on_notification
         self._rx_task: tasks.Task[None] | None = None
-        self._client: ClientWebSocketResponse | None = None
+        self._client: ClientWebSocketResponse[Literal[False]] | None = None
         self._calls: dict[int, RPCCall] = {}
         self._call_id = 0
         self._session = SessionData(f"aios-{id(self)}", None, None)
@@ -263,6 +264,7 @@ class WsRPC(WsBase):
                     scheme="http", host=self._ip_address, port=self._port, path="/rpc"
                 ),
                 heartbeat=WS_HEARTBEAT,
+                decode_text=False,
             )
         except (
             client_exceptions.WSServerHandshakeError,

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -67,7 +67,10 @@ def _receive_json_or_raise(msg: WSMessage | WSMessageTextBytes) -> dict[str, Any
         try:
             data: dict[str, Any] = json_loads(msg.data)
         except ValueError as err:
-            raise InvalidMessage(f"Received invalid JSON: {msg.data}") from err
+            payload = msg.data
+            if isinstance(payload, bytes):
+                payload = payload.decode("utf-8", errors="replace")
+            raise InvalidMessage(f"Received invalid JSON: {payload}") from err
         return data
 
     if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "aiohttp>=3.11.1",
+  "aiohttp>=3.14.0",
   "bleak-retry-connector>=3.0.0",
   "bluetooth-data-tools>=1.28.0",
   "habluetooth>=6.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ lint = [
   "ty==0.0.40",
 ]
 dev = [
-  "aioresponses==0.7.8",
   "pytest-asyncio==1.4.0",
   "pytest-cov==7.1.0",
   "pytest==9.0.3",

--- a/tests/rpc_device/conftest.py
+++ b/tests/rpc_device/conftest.py
@@ -81,7 +81,7 @@ class WsRPCMocker(WsRPC):
         shallow_copy = response.copy()
         self.next_id_mock += 1
         shallow_copy["id"] = self.next_id_mock
-        response_with_correct_id = dumps(shallow_copy).decode()
+        response_with_correct_id = dumps(shallow_copy)
         await self.response_mocker.mock_ws_message(
             WSMessage(WSMsgType.TEXT, response_with_correct_id, None)
         )

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -21,16 +21,16 @@ from .conftest import WsRPCMocker
 
 def test_receive_json_or_raise_text_returns_decoded_json() -> None:
     """Test text message with JSON payload returns decoded dict."""
-    msg = WSMessage(WSMsgType.TEXT, '{"key":"value","n":1}', None)
+    msg = WSMessage(WSMsgType.TEXT, b'{"key":"value","n":1}', None)
 
     assert _receive_json_or_raise(msg) == {"key": "value", "n": 1}
 
 
 def test_receive_json_or_raise_text_invalid_json_raises_invalid_message() -> None:
     """Test text message with invalid JSON raises InvalidMessage."""
-    msg = WSMessage(WSMsgType.TEXT, "not-json", None)
+    msg = WSMessage(WSMsgType.TEXT, b"not-json", None)
 
-    with pytest.raises(InvalidMessage, match="Received invalid JSON: not-json"):
+    with pytest.raises(InvalidMessage, match="Received invalid JSON: b'not-json'"):
         _receive_json_or_raise(msg)
 
 

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -26,11 +26,14 @@ def test_receive_json_or_raise_text_returns_decoded_json() -> None:
     assert _receive_json_or_raise(msg) == {"key": "value", "n": 1}
 
 
-def test_receive_json_or_raise_text_invalid_json_raises_invalid_message() -> None:
+@pytest.mark.parametrize("data", [b"not-json", "not-json"])
+def test_receive_json_or_raise_text_invalid_json_raises_invalid_message(
+    data: bytes | str,
+) -> None:
     """Test text message with invalid JSON raises InvalidMessage."""
-    msg = WSMessage(WSMsgType.TEXT, b"not-json", None)
+    msg = WSMessage(WSMsgType.TEXT, data, None)
 
-    with pytest.raises(InvalidMessage, match="Received invalid JSON: b'not-json'"):
+    with pytest.raises(InvalidMessage, match="Received invalid JSON: not-json"):
         _receive_json_or_raise(msg)
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,13 +1,14 @@
 """Tests for common module."""
 
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, Self
 from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import BasicAuth, ClientError, ClientSession
-from aioresponses import aioresponses
 from bleak.backends.device import BLEDevice
-from yarl import URL
 
 from aioshelly.common import (
     ConnectionOptions,
@@ -15,7 +16,6 @@ from aioshelly.common import (
     is_firmware_supported,
     process_ip_or_options,
 )
-from aioshelly.const import DEFAULT_HTTP_PORT
 from aioshelly.exceptions import (
     DeviceConnectionError,
     DeviceConnectionTimeoutError,
@@ -24,6 +24,38 @@ from aioshelly.exceptions import (
 )
 
 from .rpc_device import load_device_fixture
+
+
+class _MockResponse:
+    """Minimal async context manager mimicking an aiohttp response."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+@contextmanager
+def mock_shelly_get(
+    payload: dict[str, Any] | None = None, exception: type[Exception] | None = None
+) -> Iterator[None]:
+    """Patch ClientSession.get to return a payload or raise an exception."""
+
+    def _get(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        if exception is not None:
+            raise exception
+        assert payload is not None
+        return _MockResponse(payload)
+
+    with patch.object(ClientSession, "get", MagicMock(side_effect=_get)):
+        yield
 
 
 @pytest.mark.parametrize(
@@ -75,14 +107,7 @@ async def test_get_info() -> None:
 
     session = ClientSession()
 
-    with aioresponses() as session_mock:
-        session_mock.get(
-            URL.build(
-                scheme="http", host=ip_address, port=DEFAULT_HTTP_PORT, path="/shelly"
-            ),
-            payload=mock_response,
-        )
-
+    with mock_shelly_get(payload=mock_response):
         result = await get_info(session, ip_address, "AABBCCDDEEFF")
 
     await session.close()
@@ -98,19 +123,14 @@ async def test_get_info_mac_mismatch() -> None:
 
     session = ClientSession()
 
-    with aioresponses() as session_mock:
-        session_mock.get(
-            URL.build(
-                scheme="http", host=ip_address, port=DEFAULT_HTTP_PORT, path="/shelly"
-            ),
-            payload=mock_response,
-        )
-
-        with pytest.raises(
+    with (
+        mock_shelly_get(payload=mock_response),
+        pytest.raises(
             MacAddressMismatchError,
             match="Input MAC: 112233445566, Shelly MAC: AABBCCDDEEFF",
-        ):
-            await get_info(session, ip_address, "112233445566")
+        ),
+    ):
+        await get_info(session, ip_address, "112233445566")
 
     await session.close()
 
@@ -123,14 +143,7 @@ async def test_get_info_mac_mixed_case() -> None:
 
     session = ClientSession()
 
-    with aioresponses() as session_mock:
-        session_mock.get(
-            URL.build(
-                scheme="http", host=ip_address, port=DEFAULT_HTTP_PORT, path="/shelly"
-            ),
-            payload=mock_response,
-        )
-
+    with mock_shelly_get(payload=mock_response):
         result = await get_info(session, ip_address, "aabbccddeeff")
 
     await session.close()
@@ -153,16 +166,8 @@ async def test_get_info_exc(exc: Exception, expected_exc: Exception) -> None:
 
     session = ClientSession()
 
-    with aioresponses() as session_mock:
-        session_mock.get(
-            URL.build(
-                scheme="http", host=ip_address, port=DEFAULT_HTTP_PORT, path="/shelly"
-            ),
-            exception=exc,
-        )
-
-        with pytest.raises(expected_exc):
-            await get_info(session, ip_address, "AABBCCDDEEFF")
+    with mock_shelly_get(exception=exc), pytest.raises(expected_exc):
+        await get_info(session, ip_address, "AABBCCDDEEFF")
 
     await session.close()
 


### PR DESCRIPTION
aiohttp 3.14 added `decode_text` to `ws_connect`. Passing `decode_text=False` delivers TEXT frames as raw bytes, so orjson decodes them directly instead of decoding to str first and re-scanning. The send path already used `send_frame(json_bytes(...))`, so this finishes the round trip.

Also dropped `aioresponses` for a small local mock in the common tests. No aioresponses release works with aiohttp 3.14 yet, and it was overkill for what these tests need.