### PR TITLE
Enhance model property to return empty string if not provisioned

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -963,8 +963,8 @@ class RpcDevice:
 
     @property
     def model(self) -> str:
-        """Device model."""
-        return cast(str, self.shelly["model"])
+        """Device model or empty string if not provisioned."""
+        return cast(str, self.shelly.get("model", ""))
 
     @property
     def xmod_info(self) -> dict[str, Any]:

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -328,6 +328,22 @@ async def test_get_dynamic_components_not_supported(rpc_device: RpcDevice) -> No
 
 
 @pytest.mark.asyncio
+async def test_model_present(rpc_device: RpcDevice) -> None:
+    """Test model property returns model string when present."""
+    rpc_device._shelly = {"model": "SNSW-001P16EU"}
+
+    assert rpc_device.model == "SNSW-001P16EU"
+
+
+@pytest.mark.asyncio
+async def test_model_missing(rpc_device: RpcDevice) -> None:
+    """Test model property returns empty string when model key is absent."""
+    rpc_device._shelly = {"fw_id": "20231209-144328/1.0.0-gbf89ed5"}
+
+    assert rpc_device.model == ""
+
+
+@pytest.mark.asyncio
 async def test_shelly_gen1(client_session: ClientSession, ws_context: WsServer) -> None:
     """Test Shelly Gen1 device."""
     options = ConnectionOptions("10.10.10.10", device_mac="AABBCCDDEEFF")


### PR DESCRIPTION
Connecting a Shelly device that is missing the `model` key (a device that is not provisioned correctly resulted in the following error:
```
2026-06-07 00:42:43.300 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (task: None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 1521, in async_init
    flow, result = await self._async_init(flow_id, handler, context, data)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 1584, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 482, in _async_handle_step
    result: _FlowResultT = await getattr(flow, method)(user_input)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/shelly/config_flow.py", line 1154, in async_step_zeroconf
    self.device_info = await validate_input(
                       ^^^^^^^^^^^^^^^^^^^^^
        self.hass, self.host, self.port, self.info, {}
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/components/shelly/config_flow.py", line 170, in validate_input
    await rpc_device.initialize()
  File "/usr/local/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 254, in initialize
    await self._connect_websocket()
  File "/usr/local/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 274, in _connect_websocket
    await self._init_calls()
  File "/usr/local/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 710, in _init_calls
    await self._retrieve_blutrv_components(all_pages)
  File "/usr/local/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 1058, in _retrieve_blutrv_components
    if self.model != MODEL_BLU_GATEWAY_G3:
       ^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 967, in model
    return cast(str, self.shelly["model"])
                     ~~~~~~~~~~~^^^^^^^^^
KeyError: 'model'
```

Some Shelly devices which did not pass provision process correctly are missing the `model` key, when this happens we abort setting the device and inform the user (see https://github.com/home-assistant/core/pull/71612 https://github.com/home-assistant/core/pull/72116)

Before https://github.com/home-assistant-libs/aioshelly/pull/688 we only accessed the `model` key at Home Assistant and not at `aioshelly`, https://github.com/home-assistant-libs/aioshelly/pull/688 broke this by accessing the model key directly.
While it is possible to fix this change directly, it may easily break in the future with changes that access the `model` key.
Returning an empty string is valid since we abort the device setup later.
