### PR TITLE
Fix timeout for Add-on OTA update

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -329,7 +329,7 @@ class RpcDevice:
         params = {"stage": "beta"} if beta else {"stage": "stable"}
         await self.call_rpc("Shelly.Update", params)
 
-    async def trigger_add_on_ota_update(self, timeout: int = 300) -> None:
+    async def trigger_add_on_ota_update(self, timeout: int = 600) -> None:
         """Trigger an add-on ota update."""
         params = {"timeout": timeout}
         await self.call_rpc("AddOn.Update", params)


### PR DESCRIPTION
Current timeout value is not supported:

```
2026-07-18 12:26:20.242 DEBUG (MainThread) [aioshelly.rpc_device.wsrpc] send(192.168.1.114:80): {'id': 13, 'method': 'AddOn.Update', 'src': 'aios-129002982223760', 'params': {'timeout': 300}, 'dst': 'shelly1g4-ccba97c0b594'}
2026-07-18 12:26:20.269 DEBUG (MainThread) [aioshelly.rpc_device.wsrpc] recv(192.168.1.114:80): {'id': 13, 'src': 'shelly1g4-ccba97c0b594', 'dst': 'aios-129002982223760', 'error': {'code': -103, 'message': 'Invalid timeout'}}
2026-07-18 12:26:20.276 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [129002956790560] Error during service call to update.install: RPC call error occurred while triggering OTA update for LoRa - transmitter
```

Updating the value based on official documentation: <https://shelly-api-docs.shelly.cloud/gen2/Addons/ShellyUartAddon#addonupdate-example>

Confirmed to be working with 600.
