### PR TITLE
Add RPC cb_set method

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -563,6 +563,14 @@ class RpcDevice:
         }
         await self.call_rpc("Switch.Set", params=params)
 
+    async def cb_set(self, id_: int, output: bool) -> None:
+        """Set the output for the CB (circuit breaker) component."""
+        params = {
+            "id": id_,
+            "output": output,
+        }
+        await self.call_rpc("CB.Set", params=params)
+
     async def text_set(self, id_: int, value: str) -> None:
         """Set the value for the text component."""
         params = {

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -1673,6 +1673,20 @@ async def test_switch_set(
 
 
 @pytest.mark.asyncio
+async def test_cb_set(
+    rpc_device: RpcDevice,
+) -> None:
+    """Test RpcDevice cb_set() method."""
+    await rpc_device.cb_set(0, False)
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    call_args_list = rpc_device.call_rpc_multiple.call_args_list
+
+    assert call_args_list[0][0][0][0][0] == "CB.Set"
+    assert call_args_list[0][0][0][0][1] == {"id": 0, "output": False}
+
+
+@pytest.mark.asyncio
 async def test_smoke_mute_alarm(
     rpc_device: RpcDevice,
 ) -> None:


### PR DESCRIPTION
Add support for controlling the circuit breaker (CB) component.

API: https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/CB#cbset

Note: API has incorrect documentation - output accept true if the breaker is not in a safety limit, this has reported and discussed with Shelly and they will update the docs.

**Turn on:**
`http://192.168.1.47/rpc/CB.Set?id=0&output=true`

**Turn on response:**
`{"was_on":false}`

**Turn off:**
`http://192.168.1.47/rpc/CB.Set?id=0&output=false`

**Turn off response:**
`{"was_on":true}`
