### PR TITLE
Add Shelly Pro CB models

### DIFF
--- a/aioshelly/const.py
+++ b/aioshelly/const.py
@@ -84,6 +84,10 @@ MODEL_PRO_1 = "SPSW-001XE16EU"
 MODEL_PRO_1_V2 = "SPSW-101XE16EU"
 MODEL_PRO_1_V3 = "SPSW-201XE16EU"
 MODEL_PRO_1_V3_UL = "SPSW-201XE15UL"
+MODEL_PRO_1CB = "SPCB-01VENEU"
+MODEL_PRO_2CB = "SPCB-02VENEU"
+MODEL_PRO_3CB = "SPCB-03VENEU"
+MODEL_PRO_4CB = "SPCB-04VENEU"
 MODEL_PRO_1PM = "SPSW-001PE16EU"
 MODEL_PRO_1PM_V2 = "SPSW-101PE16EU"
 MODEL_PRO_1PM_V3 = "SPSW-201PE16EU"
@@ -749,6 +753,38 @@ DEVICES = {
         gen=GEN2,
         supported=True,
         model_id=None,  # Uses same model ID as MODEL_PRO_1
+    ),
+    MODEL_PRO_1CB: ShellyDevice(
+        model=MODEL_PRO_1CB,
+        name="Shelly Pro 1CB",
+        min_fw_date=GEN2_MIN_FIRMWARE_DATE,
+        gen=GEN2,
+        supported=True,
+        model_id=0x2013,
+    ),
+    MODEL_PRO_2CB: ShellyDevice(
+        model=MODEL_PRO_2CB,
+        name="Shelly Pro 2CB",
+        min_fw_date=GEN2_MIN_FIRMWARE_DATE,
+        gen=GEN2,
+        supported=True,
+        model_id=0x2014,
+    ),
+    MODEL_PRO_3CB: ShellyDevice(
+        model=MODEL_PRO_3CB,
+        name="Shelly Pro 3CB",
+        min_fw_date=GEN2_MIN_FIRMWARE_DATE,
+        gen=GEN2,
+        supported=True,
+        model_id=0x2015,
+    ),
+    MODEL_PRO_4CB: ShellyDevice(
+        model=MODEL_PRO_4CB,
+        name="Shelly Pro 4CB",
+        min_fw_date=GEN2_MIN_FIRMWARE_DATE,
+        gen=GEN2,
+        supported=True,
+        model_id=0x2016,
     ),
     MODEL_PRO_1PM: ShellyDevice(
         model=MODEL_PRO_1PM,


### PR DESCRIPTION
**Data collected from Shelly Pro 1CB:**

<img width="89" height="21" alt="Pro 1CB" src="https://github.com/user-attachments/assets/87a50b64-5354-449a-8bdd-bdc897b5391e" />

Discovered Shelly device: ShellyPro1CB-ABCDEF123456 (28:05:A5:CC:06:BA), model_id: 0x2013

{
  "name": "Test Pro 1CB",
  "id": "shellypro1cb-abcdef123456",
  "mac": "ABCDEF123456",
  "slot": 0,
  "model": "SPCB-01VENEU",
  "gen": 2,
  "fw_id": "20260701-130541/2.0.0-beta3-g794ffdf",
  "ver": "2.0.0-beta3",
  "app": "ProCB",
  "auth_en": false,
  "auth_domain": null,
  "provision": "complete",
  "enhanced_security": false
}

For rest of the models (`2CB`, `3CB`, `4CB`) I used: https://kb.shelly.cloud/knowledge-base/shelly-pro-cbs
