### PR TITLE
Migrate release-drafter configuration to the new structure

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,53 +3,50 @@ tag-template: "$RESOLVED_VERSION"
 
 categories:
   - title: "🚨 Breaking changes"
-    label: "breaking-change"
+    semver-increment: "major"
+    when:
+      label: "breaking-change"
 
   - title: "✨ New features"
-    label: "new-feature"
+    semver-increment: "minor"
+    when:
+      label: "new-feature"
 
   - title: "🐛 Bug fixes"
-    label: "bugfix"
+    semver-increment: "patch"
+    when:
+      label: "bugfix"
 
   - title: "🚀 Enhancements"
-    labels:
-      - "enhancement"
-      - "refactor"
-      - "performance"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "enhancement"
+        - "refactor"
+        - "performance"
 
   - title: "🧰 Maintenance"
-    labels:
-      - "maintenance"
-      - "ci"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "maintenance"
+        - "ci"
 
   - title: "📚 Documentation"
-    labels:
-      - "documentation"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "documentation"
 
   - title: "⬆️ Dependency updates"
+    semver-increment: "patch"
     collapse-after: 1
-    labels:
-      - "dependencies"
+    when:
+      labels:
+        - "dependencies"
 
-version-resolver:
-  major:
-    labels:
-      - "major"
-      - "breaking-change"
-  minor:
-    labels:
-      - "minor"
-      - "new-feature"
-  patch:
-    labels:
-      - "bugfix"
-      - "ci"
-      - "dependencies"
-      - "documentation"
-      - "enhancement"
-      - "performance"
-      - "refactor"
-  default: patch
+  - type: "version-resolver"
+    semver-increment: "patch"
 
 template: |
   ## What's Changed


### PR DESCRIPTION
Fixes deprecation warnings https://github.com/home-assistant-libs/aioshelly/actions/runs/32181308999

Relates to https://github.com/release-drafter/release-drafter/pull/1558