### PR TITLE
Use aiohttp.encode_basic_auth instead of deprecated BasicAuth

### DIFF
--- a/aioshelly/block_device/device.py
+++ b/aioshelly/block_device/device.py
@@ -162,7 +162,7 @@ class BlockDevice:
                 self.aiohttp_session, self.ip_address, self.options.device_mac
             )
 
-            if self.requires_auth and not self.options.auth:
+            if self.requires_auth and not self.options.auth_header:
                 raise InvalidAuthError("auth missing and required")
 
             async with asyncio.timeout(DEVICE_IO_TIMEOUT):
@@ -352,17 +352,20 @@ class BlockDevice:
         self, method: str, path: str, params: Any | None = None, retry: bool = True
     ) -> dict[str, Any]:
         """Device HTTP request."""
-        if self.options.auth is None and self.requires_auth:
+        if self.options.auth_header is None and self.requires_auth:
             raise InvalidAuthError("auth missing and required")
 
         host = self.ip_address
         _LOGGER.debug("host %s: http request: /%s (params=%s)", host, path, params)
+        headers = None
+        if auth_header := self.options.auth_header:
+            headers = {"Authorization": auth_header}
         try:
             resp: ClientResponse = await self.aiohttp_session.request(
                 method,
                 URL.build(scheme="http", host=host, path=f"/{path}"),
                 params=params,
-                auth=self.options.auth,
+                headers=headers,
                 raise_for_status=True,
                 timeout=HTTP_CALL_TIMEOUT_CLIENT_TIMEOUT,
             )

--- a/aioshelly/common.py
+++ b/aioshelly/common.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from socket import gethostbyname
 from typing import TYPE_CHECKING, Any
 
-from aiohttp import BasicAuth, ClientSession, ClientTimeout
+from aiohttp import ClientSession, ClientTimeout, encode_basic_auth
 from yarl import URL
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ class ConnectionOptions:
     username: str | None = None
     password: str | None = None
     temperature_unit: str = "C"
-    auth: BasicAuth | None = None
+    auth_header: str | None = None
     device_mac: str | None = None
     port: int = DEFAULT_HTTP_PORT
     ble_device: BLEDevice | None = None
@@ -68,7 +68,9 @@ class ConnectionOptions:
             if self.password is None:
                 raise ValueError("Supply both username and password")
 
-            object.__setattr__(self, "auth", BasicAuth(self.username, self.password))
+            object.__setattr__(
+                self, "auth_header", encode_basic_auth(self.username, self.password)
+            )
 
 
 IpOrOptionsType = str | ConnectionOptions

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aiohttp import BasicAuth, ClientError, ClientSession
+from aiohttp import ClientError, ClientSession, encode_basic_auth
 from bleak.backends.device import BLEDevice
 
 from aioshelly.common import (
@@ -94,7 +94,7 @@ async def test_process_ip_or_options() -> None:
     # Test ConnectionOptions
     options = ConnectionOptions(ip, "user", "pass")
     assert await process_ip_or_options(options) == options
-    assert options.auth == BasicAuth("user", "pass")
+    assert options.auth_header == encode_basic_auth("user", "pass")
 
     # Test missing password
     with pytest.raises(ValueError, match="Supply both username and password"):


### PR DESCRIPTION
`aiohttp.BasicAuth` and the request `auth` parameter are deprecated and will be removed in aiohttp 4.0. Using `aiohttp.encode_basic_auth()` with an `Authorization` header now makes that migration a non-event.

aiohttp is already pinned to >=3.14.0, which is the version that added `encode_basic_auth()`.

`ConnectionOptions.auth` becomes `ConnectionOptions.auth_header` and now holds the header value. It is still set from `username`/`password`, so callers that pass credentials are unaffected.

I'm a bot, asked by @balloob to fix this because the deprecation warning shows up in Home Assistant CI.