### PR TITLE
Add `ir_emit_raw` method

### DIFF
--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -683,6 +683,11 @@ class RpcDevice:
         params = {"id": id_, "config": {"rtsp": {"enable": value}}}
         await self.call_rpc("Camera.SetConfig", params)
 
+    async def ir_emit_raw(self, timings: list[int], freq: int, repeats: int) -> None:
+        """Emit raw IR data."""
+        params = {"timings": timings, "freq": freq, "repeats": repeats}
+        await self.call_rpc("IR.EmitRaw", params)
+
     async def poll(self) -> None:
         """Poll device for calls that do not receive push updates."""
         calls: list[tuple[str, dict[str, Any] | None]] = [("Shelly.GetStatus", None)]

--- a/aioshelly/rpc_device/device.py
+++ b/aioshelly/rpc_device/device.py
@@ -683,7 +683,9 @@ class RpcDevice:
         params = {"id": id_, "config": {"rtsp": {"enable": value}}}
         await self.call_rpc("Camera.SetConfig", params)
 
-    async def ir_emit_raw(self, timings: list[int], freq: int, repeats: int) -> None:
+    async def ir_emit_raw(
+        self, timings: list[int], freq: int = 38000, repeats: int = 0
+    ) -> None:
         """Emit raw IR data."""
         params = {"timings": timings, "freq": freq, "repeats": repeats}
         await self.call_rpc("IR.EmitRaw", params)

--- a/tests/rpc_device/test_device.py
+++ b/tests/rpc_device/test_device.py
@@ -2269,3 +2269,22 @@ async def test_set_camera_rtsp(
         "id": 2,
         "config": {"rtsp": {"enable": True}},
     }
+
+
+@pytest.mark.asyncio
+async def test_ir_emit_raw(
+    rpc_device: RpcDevice,
+) -> None:
+    """Test RpcDevice ir_emit_raw() method."""
+    await rpc_device.ir_emit_raw(
+        [4500, -4500, 560, -1690, 560, -560, 560, -40000], 38000, 3
+    )
+
+    assert rpc_device.call_rpc_multiple.call_count == 1
+    call_args_list = rpc_device.call_rpc_multiple.call_args_list
+    assert call_args_list[0][0][0][0][0] == "IR.EmitRaw"
+    assert call_args_list[0][0][0][0][1] == {
+        "timings": [4500, -4500, 560, -1690, 560, -560, 560, -40000],
+        "freq": 38000,
+        "repeats": 3,
+    }


### PR DESCRIPTION
## `IR.EmitRaw` — Detailed API
 
On-demand raw IR transmit. Sends a pulse list passed **at call time** — no
learning, no stored component. This is the method HA's IR emitter integration
targets.
 
### Request
 
`POST http://<device>/rpc/IR.EmitRaw`
 
```json
{
  "timings": [4500, -4500, 560, -1690, 560, -560, 560, -40000],
  "freq": 38000,
  "repeats": 0
}
```
 
### Parameters
 
| Field | Type | Required | Default | Range | Description |
|-------|------|----------|---------|-------|-------------|
| `timings` | array of signed int | yes | — | 1..`kMaxRawTimings` (1024) | Pulse durations in **microseconds**. **`+` = mark** (carrier/LED on), **`−` = space** (off). Values alternate mark/space and are packed two-per `rmt_symbol_word_t`. Odd length → the last symbol's `duration1` is 0 (end marker). |
| `freq` | int | no | `38000` | `kMinCarrierHz`..`kMaxCarrierHz` (20000..60000) | Carrier frequency in Hz. Applied via `IrDriver::SetCarrierFreq`, which re-applies the carrier only when it changes (e.g. 40000 for Sony). |
| `repeats` | int | no | `0` | 0..`kMaxRepeats-1` | **Extra** repeats. `0` = send once. Total transmissions = `repeats + 1`. |