### PR TITLE
Drop the cached auth nonce when the device answers 429

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -461,7 +461,7 @@ class WsRPC(WsBase):
         except KeyError as err:
             raise RpcCallError(0, f"bad response: {resp}") from err
 
-                if code != HTTPStatus.UNAUTHORIZED.value:
+        if code != HTTPStatus.UNAUTHORIZED.value:
             if (
                 code == HTTPStatus.TOO_MANY_REQUESTS.value
                 and (auth_data := self._session.auth_data) is not None

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -461,7 +461,17 @@ class WsRPC(WsBase):
         except KeyError as err:
             raise RpcCallError(0, f"bad response: {resp}") from err
 
-        if code != HTTPStatus.UNAUTHORIZED.value:
+                if code != HTTPStatus.UNAUTHORIZED.value:
+            if (
+                code == HTTPStatus.TOO_MANY_REQUESTS.value
+                and (auth_data := self._session.auth_data) is not None
+            ):
+                # A device that throttles repeated failed authentications answers
+                # 429 instead of issuing a new 401 challenge, so the cached nonce
+                # can no longer be refreshed through the usual path. Replaying it
+                # makes every following call fail as well, so drop it and let the
+                # next call solicit a fresh challenge.
+                auth_data.nonce = ""
             raise RpcCallError(code, msg)
 
         if allow_auth_retry and self._session.auth_data is not None:

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -108,6 +108,7 @@ async def test_device_wscall_auth_retry(ws_rpc_with_auth: WsRPCMocker) -> None:
     results = await ws_rpc_with_auth.calls_with_mocked_responses(calls, responses)
     assert results[0] == cover_close_success["result"]
 
+
 @pytest.mark.asyncio
 async def test_device_wscall_throttled_drops_stale_nonce(
     ws_rpc_with_auth: WsRPCMocker,

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -133,7 +133,8 @@ async def test_device_wscall_throttled_drops_stale_nonce(
         )
 
     assert auth_data.nonce == ""
-    
+
+
 def test_auth_update_challenge_unsupported_algorithm() -> None:
     """Test challenge update raises when algorithm is unsupported."""
     auth_data = AuthData("auth_domain", "username", "password")

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -12,6 +12,7 @@ from aioshelly.exceptions import (
     DeviceConnectionTimeoutError,
     InvalidAuthError,
     InvalidMessage,
+    RpcCallError,
 )
 from aioshelly.rpc_device.wsrpc import AuthData, _receive_json_or_raise
 
@@ -107,7 +108,32 @@ async def test_device_wscall_auth_retry(ws_rpc_with_auth: WsRPCMocker) -> None:
     results = await ws_rpc_with_auth.calls_with_mocked_responses(calls, responses)
     assert results[0] == cover_close_success["result"]
 
+@pytest.mark.asyncio
+async def test_device_wscall_throttled_drops_stale_nonce(
+    ws_rpc_with_auth: WsRPCMocker,
+) -> None:
+    """Test that a 429 response drops the cached nonce.
 
+    A throttled device answers 429 instead of a 401 challenge, so the nonce
+    cannot be refreshed through the usual path. Keeping it would make every
+    subsequent call fail as well.
+    """
+    ws_rpc_with_auth.set_auth_data("auth_domain", "username", "password")
+    auth_data = ws_rpc_with_auth._session.auth_data
+    assert auth_data is not None
+    auth_data.update_challenge({"nonce": "stale_nonce", "algorithm": "SHA-256"})
+
+    throttled = {
+        "error": {"code": 429, "message": "Too many failed authentication attempts"}
+    }
+
+    with pytest.raises(RpcCallError):
+        await ws_rpc_with_auth.calls_with_mocked_responses(
+            [("Cover.Close", {"id": 0})], [throttled]
+        )
+
+    assert auth_data.nonce == ""
+    
 def test_auth_update_challenge_unsupported_algorithm() -> None:
     """Test challenge update raises when algorithm is unsupported."""
     auth_data = AuthData("auth_domain", "username", "password")


### PR DESCRIPTION
Problem
_raise_for_unrecoverable_errors() refreshes the auth challenge only for 401. Every other code, including 429, raises immediately and leaves AuthData untouched.

Per the [Gen2 authentication docs](https://shelly-api-docs.shelly.cloud/gen2/General/Authentication/), a device counts failed authentications in a 10-minute sliding window and, once throttled, answers 429 instead of 401 — including for requests that would otherwise hand out a fresh nonce. So exactly when a new challenge is needed, the code path that would obtain one is unreachable.

That turns a transient condition into a persistent one. The cached nonce is dead, every following call resends it with only nc incremented, each one counts as another failed authentication, and the window is continuously re-armed. A device whose coordinator keeps polling never falls silent long enough for the throttle to drain.

Observed on a device in this state: the same nonce went out with nc climbing 2 → 53 without a single refresh attempt, while a separate WebSocket client authenticated and executed Switch.Set against that same device successfully at that moment. Reloading the config entry did not help either, since AuthData survives it — from the user's side the device is simply gone.

Change
On 429, drop the cached nonce. The next request then goes out unauthenticated and picks up a fresh challenge through the existing retry path, instead of replaying one the device has already rejected. The call itself still raises RpcCallError, so nothing changes for callers.

This is deliberately minimal: no retry loop and no timer. It only removes the state that prevents recovery. Adding a real backoff — not sending anything for a while after a 429, since requests inside the window extend it, worst case 5 minutes — would be a sensible follow-up, but it needs new state and is a larger discussion.

Context
The firmware side that made this visible is fixed in Shelly 2.0.1-beta1 (see [home-assistant/core#177257](https://github.com/home-assistant/core/issues/177257), and #1230 for the matching once-per-nonce-lifetime poll failure). This change is about the library's own behaviour, which stays a robustness gap regardless of firmware: any future throttle wedges the connection the same way.

Also worth considering separately: RpcCallError's code and message are dropped before the error reaches the user. In Home Assistant, components/shelly/entity.py maps every RpcCallError to rpc_call_action_error with only the entity and device name, so the log line gives no hint that an authentication throttle is involved. Surfacing the device's code and message would make this class of problem far easier to recognise.