### PR TITLE
Handle `stale` flag for `nonce` from firmware 2.0+

### DIFF
--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -503,7 +503,7 @@ class WsRPC(WsBase):
                     if TYPE_CHECKING:
                         assert self._session.auth_data
 
-                    # Parse challenge first to detect stale nonces (firmware >=2.0.0)
+                    # Check if the error is due to a stale nonce (firmware >=2.0.0)
                     is_stale = (
                         error.get("code") == HTTPStatus.UNAUTHORIZED.value
                         and auth_challenge.get("stale") is True

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -450,16 +450,25 @@ class WsRPC(WsBase):
         """Websocket RPC call."""
         return (await self.calls([(method, params)], timeout))[0]
 
-    def _raise_for_unrecoverable_errors(
-        self, resp: dict[str, Any], allow_auth_retry: bool
-    ) -> None:
-        """Raise for unrecoverable errors."""
+    @staticmethod
+    def _parse_rpc_error(resp: dict[str, Any]) -> tuple[dict[str, Any], int, str]:
+        """Extract error dict, code, and message from an RPC error response.
+
+        Raises RpcCallError if the response structure is invalid.
+        """
         try:
             error = resp["error"]
             code = error["code"]
             msg = error["message"]
         except KeyError as err:
             raise RpcCallError(0, f"bad response: {resp}") from err
+        return error, code, msg
+
+    def _raise_for_unrecoverable_errors(
+        self, resp: dict[str, Any], allow_auth_retry: bool
+    ) -> None:
+        """Raise for unrecoverable errors."""
+        _error, code, msg = self._parse_rpc_error(resp)
 
         if code != HTTPStatus.UNAUTHORIZED.value:
             raise RpcCallError(code, msg)
@@ -497,10 +506,10 @@ class WsRPC(WsBase):
                 # Wait response
                 response = await call.resolve
                 if "result" not in response:
+                    error, code, msg = self._parse_rpc_error(response)
                     try:
-                        error = response["error"]
                         auth_challenge = json_loads(error["message"])
-                    except (ValueError, KeyError, TypeError):
+                    except (ValueError, TypeError):
                         self._raise_for_unrecoverable_errors(response, allow_auth_retry)
                         raise
 
@@ -509,12 +518,12 @@ class WsRPC(WsBase):
 
                     # Check if the error is due to a stale nonce (firmware >=2.0.0)
                     is_stale = (
-                        error.get("code") == HTTPStatus.UNAUTHORIZED.value
+                        code == HTTPStatus.UNAUTHORIZED.value
                         and auth_challenge.get("stale") is True
                     )
                     if is_stale:
                         if stale_retry:
-                            raise InvalidAuthError(error["message"])
+                            raise InvalidAuthError(msg)
 
                         self._session.auth_data.update_challenge(auth_challenge)
                         return await self._rpc_call_with_auth_retry(

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -497,8 +497,12 @@ class WsRPC(WsBase):
                 # Wait response
                 response = await call.resolve
                 if "result" not in response:
-                    error = response["error"]
-                    auth_challenge = json_loads(error["message"])
+                    try:
+                        error = response["error"]
+                        auth_challenge = json_loads(error["message"])
+                    except (ValueError, KeyError, TypeError):
+                        self._raise_for_unrecoverable_errors(response, allow_auth_retry)
+                        raise
 
                     if TYPE_CHECKING:
                         assert self._session.auth_data

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -252,6 +252,7 @@ class WsRPC(WsBase):
         self._calls: dict[int, RPCCall] = {}
         self._call_id = 0
         self._session = SessionData(f"aios-{id(self)}", None, None)
+        self._auth_lock = asyncio.Lock()
         self._loop = asyncio.get_running_loop()
 
     @property
@@ -575,14 +576,18 @@ class WsRPC(WsBase):
         if self._session.auth_data is not None:
             # sequential: each call uses fresh nc from prior challenge,
             # first call seeds the nonce via 401 challenge
-            results = []
-            deadline = self._loop.time() + timeout
-            for method, params in calls:
-                remaining = deadline - self._loop.time()
-                results.append(
-                    await self._rpc_call_with_auth_retry(method, params, remaining)
-                )
-            return results
+            # Lock prevents concurrent callers from receiving the same
+            # stale challenge and mutating shared AuthData, which would
+            # cause duplicate nonce/count pairs and spurious 401s.
+            async with self._auth_lock:
+                results = []
+                deadline = self._loop.time() + timeout
+                for method, params in calls:
+                    remaining = deadline - self._loop.time()
+                    results.append(
+                        await self._rpc_call_with_auth_retry(method, params, remaining)
+                    )
+                return results
 
         results = await self._rpc_calls(calls, timeout)
         return [call.result for call in results]

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -452,16 +452,14 @@ class WsRPC(WsBase):
 
     @staticmethod
     def _parse_rpc_error(resp: dict[str, Any]) -> tuple[dict[str, Any], int, str]:
-        """Extract error dict, code, and message from an RPC error response.
-
-        Raises RpcCallError if the response structure is invalid.
-        """
+        """Extract error dict, code, and message from an RPC error response."""
         try:
             error = resp["error"]
             code = error["code"]
             msg = error["message"]
         except KeyError as err:
             raise RpcCallError(0, f"bad response: {resp}") from err
+
         return error, code, msg
 
     def _raise_for_unrecoverable_errors(

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -475,6 +475,7 @@ class WsRPC(WsBase):
         params: dict[str, Any] | None = None,
         timeout: float = 10.0,
         allow_auth_retry: bool = True,
+        stale_retry: bool = False,
     ) -> dict[str, Any]:
         """Websocket RPC call with authentication retry."""
         if self._client is None:
@@ -496,16 +497,38 @@ class WsRPC(WsBase):
                 # Wait response
                 response = await call.resolve
                 if "result" not in response:
-                    self._raise_for_unrecoverable_errors(response, allow_auth_retry)
-                    auth_challenge = json_loads(response["error"]["message"])
+                    error = response["error"]
+                    auth_challenge = json_loads(error["message"])
+
                     if TYPE_CHECKING:
                         assert self._session.auth_data
+
+                    # Parse challenge first to detect stale nonces (firmware >=2.0.0)
+                    is_stale = (
+                        error.get("code") == HTTPStatus.UNAUTHORIZED.value
+                        and auth_challenge.get("stale") is True
+                    )
+                    if is_stale:
+                        if stale_retry:
+                            raise InvalidAuthError(error["message"])
+
+                        self._session.auth_data.update_challenge(auth_challenge)
+                        return await self._rpc_call_with_auth_retry(
+                            method,
+                            params,
+                            timeout,
+                            allow_auth_retry=False,
+                            stale_retry=True,
+                        )
+
+                    self._raise_for_unrecoverable_errors(response, allow_auth_retry)
                     self._session.auth_data.update_challenge(auth_challenge)
                     return await self._rpc_call_with_auth_retry(
                         method,
                         params,
                         timeout,
                         allow_auth_retry=False,
+                        stale_retry=stale_retry,
                     )
                 call.result = response["result"]
         except TimeoutError as exc:

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -505,6 +505,8 @@ class WsRPC(WsBase):
                 response = await call.resolve
                 if "result" not in response:
                     error, code, msg = self._parse_rpc_error(response)
+                    if code != HTTPStatus.UNAUTHORIZED.value:
+                        raise RpcCallError(code, msg)
                     try:
                         auth_challenge = json_loads(error["message"])
                     except ValueError as err:

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -503,7 +503,11 @@ class WsRPC(WsBase):
                 response = await call.resolve
                 if "result" not in response:
                     error, code, msg = self._parse_rpc_error(response)
-                    self._raise_for_unrecoverable_errors(code, msg, allow_auth_retry)
+
+                    # Non-401 errors are always unrecoverable
+                    if code != HTTPStatus.UNAUTHORIZED.value:
+                        raise RpcCallError(code, msg)
+
                     try:
                         auth_challenge = json_loads(error["message"])
                     except ValueError as err:
@@ -513,10 +517,7 @@ class WsRPC(WsBase):
                         assert self._session.auth_data
 
                     # Check if the error is due to a stale nonce (firmware >=2.0.0)
-                    is_stale = (
-                        code == HTTPStatus.UNAUTHORIZED.value
-                        and auth_challenge.get("stale") is True
-                    )
+                    is_stale = auth_challenge.get("stale") is True
                     if is_stale:
                         if stale_retry:
                             raise InvalidAuthError(msg)
@@ -529,6 +530,10 @@ class WsRPC(WsBase):
                             allow_auth_retry=False,
                             stale_retry=True,
                         )
+
+                    # Non-stale 401: check if auth retry is allowed
+                    if not allow_auth_retry or self._session.auth_data is None:
+                        raise InvalidAuthError(msg)
 
                     self._session.auth_data.update_challenge(auth_challenge)
                     return await self._rpc_call_with_auth_retry(

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -463,11 +463,9 @@ class WsRPC(WsBase):
         return error, code, msg
 
     def _raise_for_unrecoverable_errors(
-        self, resp: dict[str, Any], allow_auth_retry: bool
+        self, code: int, msg: str, allow_auth_retry: bool
     ) -> None:
         """Raise for unrecoverable errors."""
-        _, code, msg = self._parse_rpc_error(resp)
-
         if code != HTTPStatus.UNAUTHORIZED.value:
             raise RpcCallError(code, msg)
 
@@ -505,8 +503,7 @@ class WsRPC(WsBase):
                 response = await call.resolve
                 if "result" not in response:
                     error, code, msg = self._parse_rpc_error(response)
-                    if code != HTTPStatus.UNAUTHORIZED.value:
-                        raise RpcCallError(code, msg)
+                    self._raise_for_unrecoverable_errors(code, msg, allow_auth_retry)
                     try:
                         auth_challenge = json_loads(error["message"])
                     except ValueError as err:
@@ -533,7 +530,6 @@ class WsRPC(WsBase):
                             stale_retry=True,
                         )
 
-                    self._raise_for_unrecoverable_errors(response, allow_auth_retry)
                     self._session.auth_data.update_challenge(auth_challenge)
                     return await self._rpc_call_with_auth_retry(
                         method,
@@ -618,8 +614,9 @@ class WsRPC(WsBase):
                 for call in sent_calls:
                     response = await call.resolve
                     if "result" not in response:
+                        _, code, msg = self._parse_rpc_error(response)
                         self._raise_for_unrecoverable_errors(
-                            response, allow_auth_retry=False
+                            code, msg, allow_auth_retry=False
                         )
                     else:
                         call.result = response["result"]

--- a/aioshelly/rpc_device/wsrpc.py
+++ b/aioshelly/rpc_device/wsrpc.py
@@ -468,7 +468,7 @@ class WsRPC(WsBase):
         self, resp: dict[str, Any], allow_auth_retry: bool
     ) -> None:
         """Raise for unrecoverable errors."""
-        _error, code, msg = self._parse_rpc_error(resp)
+        _, code, msg = self._parse_rpc_error(resp)
 
         if code != HTTPStatus.UNAUTHORIZED.value:
             raise RpcCallError(code, msg)
@@ -509,9 +509,8 @@ class WsRPC(WsBase):
                     error, code, msg = self._parse_rpc_error(response)
                     try:
                         auth_challenge = json_loads(error["message"])
-                    except (ValueError, TypeError):
-                        self._raise_for_unrecoverable_errors(response, allow_auth_retry)
-                        raise
+                    except ValueError as err:
+                        raise InvalidAuthError(msg) from err
 
                     if TYPE_CHECKING:
                         assert self._session.auth_data

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -294,6 +294,19 @@ async def test_double_stale_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_stale_retry_guard_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
+    """Test stale_retry guard raises InvalidAuthError on second stale 401."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    first_stale = make_401_response("nonce1", True, 1)
+    second_stale = make_401_response("nonce2", True, 1)
+
+    with pytest.raises(InvalidAuthError):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Shelly.GetConfig", None)], [first_stale, second_stale]
+        )
+
+
+@pytest.mark.asyncio
 async def test_rpc_call_invalid_json_401(
     ws_rpc: WsRPCMocker,
 ) -> None:

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -13,6 +13,7 @@ from aioshelly.exceptions import (
     DeviceConnectionTimeoutError,
     InvalidAuthError,
     InvalidMessage,
+    RpcCallError,
 )
 from aioshelly.json import json_dumps
 from aioshelly.rpc_device.wsrpc import AuthData, _receive_json_or_raise
@@ -294,15 +295,34 @@ async def test_double_stale_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stale_retry_guard_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
-    """Test stale_retry guard raises InvalidAuthError on second stale 401."""
+async def test_rpc_call_non401_error_raises_rpc_call_error(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test non-401 error response raises RpcCallError."""
     ws_rpc.set_auth_data("auth_domain", "username", "password")
-    first_stale = make_401_response("nonce1", True, 1)
-    second_stale = make_401_response("nonce2", True, 1)
+    bad_response = {
+        "src": "shellyplus2pm-aabbccddeeff",
+        "error": {"code": 404, "message": "Not Found"},
+    }
+
+    with pytest.raises(RpcCallError, match="Not Found"):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Shelly.GetConfig", None)], [bad_response]
+        )
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_double_nonstale_401_raises_invalid_auth(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test two consecutive non-stale 401 responses raise InvalidAuthError."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    first = make_401_response("nonce1", stale=False, nc=1)
+    second = make_401_response("nonce2", stale=False, nc=1)
 
     with pytest.raises(InvalidAuthError):
         await ws_rpc.calls_with_mocked_responses(
-            [("Shelly.GetConfig", None)], [first_stale, second_stale]
+            [("Shelly.GetConfig", None)], [first, second]
         )
 
 

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -291,3 +291,20 @@ async def test_double_stale_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
         await ws_rpc.calls_with_mocked_responses(
             [("Cover.Close", {"id": 0})], [first, second]
         )
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_invalid_json_401(
+    ws_rpc: WsRPCMocker,
+) -> None:
+    """Test 401 with invalid JSON raises InvalidAuthError."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    bad_401 = {
+        "src": "shellyplus2pm-aabbccddeeff",
+        "error": {"code": 401, "message": "lorem-ipsum"},
+    }
+
+    with pytest.raises(InvalidAuthError, match="lorem-ipsum"):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Shelly.GetConfig", None)], [bad_401]
+        )

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -1,7 +1,6 @@
 """Tests for rpc_device.wsrpc module."""
 
 import asyncio
-import json
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -15,6 +14,7 @@ from aioshelly.exceptions import (
     InvalidAuthError,
     InvalidMessage,
 )
+from aioshelly.json import json_dumps
 from aioshelly.rpc_device.wsrpc import AuthData, _receive_json_or_raise
 
 from . import load_device_fixture
@@ -33,12 +33,11 @@ def make_401_response(
         "nc": nc,
         "realm": "shellyplus2pm-aabbccddeeff",
         "algorithm": "SHA-256",
+        "stale": stale,
     }
-    if stale is not None:
-        challenge["stale"] = stale
     return {
         "src": "shellyplus2pm-aabbccddeeff",
-        "error": {"code": 401, "message": json.dumps(challenge)},
+        "error": {"code": 401, "message": json_dumps(challenge)},
     }
 
 

--- a/tests/rpc_device/test_wsrpc.py
+++ b/tests/rpc_device/test_wsrpc.py
@@ -1,7 +1,9 @@
 """Tests for rpc_device.wsrpc module."""
 
 import asyncio
+import json
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,6 +19,32 @@ from aioshelly.rpc_device.wsrpc import AuthData, _receive_json_or_raise
 
 from . import load_device_fixture
 from .conftest import WsRPCMocker
+
+
+def make_401_response(
+    nonce: str,
+    stale: bool = False,
+    nc: int = 1,
+) -> dict[str, Any]:
+    """Build a 401 error response with JSON-encoded digest challenge."""
+    challenge: dict[str, Any] = {
+        "auth_type": "digest",
+        "nonce": nonce,
+        "nc": nc,
+        "realm": "shellyplus2pm-aabbccddeeff",
+        "algorithm": "SHA-256",
+    }
+    if stale is not None:
+        challenge["stale"] = stale
+    return {
+        "src": "shellyplus2pm-aabbccddeeff",
+        "error": {"code": 401, "message": json.dumps(challenge)},
+    }
+
+
+def make_success_response(result: dict[str, Any]) -> dict[str, Any]:
+    """Build a successful result response."""
+    return {"src": "shellyplus2pm-aabbccddeeff", "result": result}
 
 
 def test_receive_json_or_raise_text_returns_decoded_json() -> None:
@@ -233,3 +261,34 @@ async def test_wscall_debug_logs_result_with_auth(
     assert (
         f"result(127.0.0.1:80): Shelly.GetConfig(None) -> {config_response['result']}"
     ) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stale_true_triggers_retry_and_succeeds(ws_rpc: WsRPCMocker) -> None:
+    """Test stale=true triggers retry with new nonce and succeeds."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    stale_challenge = make_401_response("nonce_value", True, 1)
+    success = make_success_response({"ok": True})
+
+    results = await ws_rpc.calls_with_mocked_responses(
+        [("Cover.Close", {"id": 0})], [stale_challenge, success]
+    )
+
+    assert results[0] == {"ok": True}
+    # Verify nonce and nc were updated (nc incremented after get_auth)
+    assert ws_rpc._session.auth_data is not None
+    assert ws_rpc._session.auth_data.nonce == "nonce_value"
+    assert ws_rpc._session.auth_data.nc == 2
+
+
+@pytest.mark.asyncio
+async def test_double_stale_raises_invalid_auth(ws_rpc: WsRPCMocker) -> None:
+    """Test double stale true raises InvalidAuthError (guard)."""
+    ws_rpc.set_auth_data("auth_domain", "username", "password")
+    first = make_401_response("nonce_value", True, 1)
+    second = make_401_response("nonce_value", True, 1)
+
+    with pytest.raises(InvalidAuthError):
+        await ws_rpc.calls_with_mocked_responses(
+            [("Cover.Close", {"id": 0})], [first, second]
+        )


### PR DESCRIPTION
https://shelly-api-docs.shelly.cloud/gen2/General/Authentication#efficient-authentication-with-nonce-reuse-firmware-200